### PR TITLE
Addition of Microsoft Cognitive Translation Service and a Tab to select the preferred Translations service

### DIFF
--- a/AutoResxTranslator/AutoResxTranslator.csproj
+++ b/AutoResxTranslator/AutoResxTranslator.csproj
@@ -59,11 +59,13 @@
       <DependentUpon>frmMain.cs</DependentUpon>
     </Compile>
     <Compile Include="GTranslateService.cs" />
+    <Compile Include="MSTranslateService.cs" />
     <Compile Include="OpResult.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResxExcel.cs" />
     <Compile Include="ResxTranslator.cs" />
+    <Compile Include="ServiceEnum.cs" />
     <Compile Include="SimpleJson.cs" />
     <EmbeddedResource Include="frmAbout.resx">
       <DependentUpon>frmAbout.cs</DependentUpon>

--- a/AutoResxTranslator/MSTranslateService.cs
+++ b/AutoResxTranslator/MSTranslateService.cs
@@ -30,40 +30,51 @@ namespace AutoResxTranslator
 
             string route = "/translate?api-version=3.0&to=" + toLanguage + "&from=" + fromLanguage;
 
-            object[] body = new object[] { new { Text = text } };
-            var requestBody = JsonConvert.SerializeObject(body);
-
-            using (var client = new HttpClient())
-            using (var request = new HttpRequestMessage())
+            try
             {
-                // Build the request.
-                request.Method = HttpMethod.Post;
-                request.RequestUri = new Uri(host + route);
-                request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-                request.Headers.Add("Ocp-Apim-Subscription-Region", region);
+                object[] body = new object[] { new { Text = text } };
+                var requestBody = JsonConvert.SerializeObject(body);
 
-                // Send the request and get response.
-                HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
-
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                using (var client = new HttpClient())
+                using (var request = new HttpRequestMessage())
                 {
-                    // Read response as a string.
-                    string resultFromMS = await response.Content.ReadAsStringAsync();
-                    TranslationResult[] deserializedOutput = JsonConvert.DeserializeObject<TranslationResult[]>(resultFromMS);
-                    // Iterate over the deserialized results.
-                    foreach (TranslationResult o in deserializedOutput)
+                    // Build the request.
+                    request.Method = HttpMethod.Post;
+                    request.RequestUri = new Uri(host + route);
+                    request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                    request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+                    request.Headers.Add("Ocp-Apim-Subscription-Region", region);
+
+                    // Send the request and get response.
+                    HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
+
+                    if (response.StatusCode == System.Net.HttpStatusCode.OK)
                     {
-                        // Print the detected input languge and confidence score.
-                        Console.WriteLine("Detected input language: {0}\nConfidence score: {1}\n", o.DetectedLanguage.Language, o.DetectedLanguage.Score);
-                        // Iterate over the results and print each translation.
-                        foreach (Translation t in o.Translations)
+                        // Read response as a string.
+                        string resultFromMS = await response.Content.ReadAsStringAsync();
+                        TranslationResult[] deserializedOutput = JsonConvert.DeserializeObject<TranslationResult[]>(resultFromMS);
+                        // Iterate over the deserialized results.
+                        foreach (TranslationResult o in deserializedOutput)
                         {
-                            Console.WriteLine("Translated to {0}: {1}", t.To, t.Text);
-                            return t.Text;
+                            // Print the detected input languge and confidence score.
+                            Console.WriteLine("Detected input language: {0}\nConfidence score: {1}\n", o.DetectedLanguage.Language, o.DetectedLanguage.Score);
+                            // Iterate over the results and print each translation.
+                            foreach (Translation t in o.Translations)
+                            {
+                                Console.WriteLine("Translated to {0}: {1}", t.To, t.Text);
+                                return t.Text;
+                            }
                         }
                     }
+                    else
+                    {
+                        return "Translation failed! Exception: " + response.ReasonPhrase;
+                    }
                 }
+            }
+            catch (Exception e)
+            {
+                return "Translation failed! Exception: " + e.Message;
             }
             return null;
         }

--- a/AutoResxTranslator/MSTranslateService.cs
+++ b/AutoResxTranslator/MSTranslateService.cs
@@ -56,12 +56,9 @@ namespace AutoResxTranslator
                         // Iterate over the deserialized results.
                         foreach (TranslationResult o in deserializedOutput)
                         {
-                            // Print the detected input languge and confidence score.
-                            Console.WriteLine("Detected input language: {0}\nConfidence score: {1}\n", o.DetectedLanguage.Language, o.DetectedLanguage.Score);
-                            // Iterate over the results and print each translation.
+                            // Iterate over the results, return the first result
                             foreach (Translation t in o.Translations)
                             {
-                                Console.WriteLine("Translated to {0}: {1}", t.To, t.Text);
                                 return t.Text;
                             }
                         }

--- a/AutoResxTranslator/MSTranslateService.cs
+++ b/AutoResxTranslator/MSTranslateService.cs
@@ -1,0 +1,113 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Net.Http;
+
+namespace AutoResxTranslator
+{
+    /// <summary>
+    /// Translation service using Microsoft Cogntive service.
+    /// 
+    /// ref: https://azure.microsoft.com/en-in/services/cognitive-services/translator-text-api/
+    /// </summary>
+    public class MSTranslateService
+    {
+        private static string host = "https://api-apc.cognitive.microsofttranslator.com";
+        private static string subscriptionKey = "<YOUR-SUBSCRIPTION-KEY-HERE>";
+        private static string region = "centralindia";
+
+        public static async System.Threading.Tasks.Task<string> TranslateAsync(
+            string text,
+            string fromLanguage,
+            string toLanguage)
+        {
+            if (fromLanguage.Equals("auto") || fromLanguage.Equals(""))
+            {
+                fromLanguage = null;
+            }
+
+            string route = "/translate?api-version=3.0&to=" + toLanguage + "&from=" + fromLanguage;
+
+            object[] body = new object[] { new { Text = text } };
+            var requestBody = JsonConvert.SerializeObject(body);
+
+            using (var client = new HttpClient())
+            using (var request = new HttpRequestMessage())
+            {
+                // Build the request.
+                request.Method = HttpMethod.Post;
+                request.RequestUri = new Uri(host + route);
+                request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+                request.Headers.Add("Ocp-Apim-Subscription-Region", region);
+
+                // Send the request and get response.
+                HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
+
+                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                {
+                    // Read response as a string.
+                    string resultFromMS = await response.Content.ReadAsStringAsync();
+                    TranslationResult[] deserializedOutput = JsonConvert.DeserializeObject<TranslationResult[]>(resultFromMS);
+                    // Iterate over the deserialized results.
+                    foreach (TranslationResult o in deserializedOutput)
+                    {
+                        // Print the detected input languge and confidence score.
+                        Console.WriteLine("Detected input language: {0}\nConfidence score: {1}\n", o.DetectedLanguage.Language, o.DetectedLanguage.Score);
+                        // Iterate over the results and print each translation.
+                        foreach (Translation t in o.Translations)
+                        {
+                            Console.WriteLine("Translated to {0}: {1}", t.To, t.Text);
+                            return t.Text;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The C# classes that represents the JSON returned by the Translator Text API.
+    /// </summary>
+    public class TranslationResult
+    {
+        public DetectedLanguage DetectedLanguage { get; set; }
+        public TextResult SourceText { get; set; }
+        public Translation[] Translations { get; set; }
+    }
+
+    public class DetectedLanguage
+    {
+        public string Language { get; set; }
+        public float Score { get; set; }
+    }
+
+    public class TextResult
+    {
+        public string Text { get; set; }
+        public string Script { get; set; }
+    }
+
+    public class Translation
+    {
+        public string Text { get; set; }
+        public TextResult Transliteration { get; set; }
+        public string To { get; set; }
+        public Alignment Alignment { get; set; }
+        public SentenceLength SentLen { get; set; }
+    }
+
+    public class Alignment
+    {
+        public string Proj { get; set; }
+    }
+
+    public class SentenceLength
+    {
+        public int[] SrcSentLen { get; set; }
+        public int[] TransSentLen { get; set; }
+    }
+}

--- a/AutoResxTranslator/ServiceEnum.cs
+++ b/AutoResxTranslator/ServiceEnum.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoResxTranslator
+{
+    public enum ServiceEnum
+    {
+        Microsoft,
+        Google
+    }
+}

--- a/AutoResxTranslator/frmMain.Designer.cs
+++ b/AutoResxTranslator/frmMain.Designer.cs
@@ -28,620 +28,676 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.Windows.Forms.ListViewItem listViewItem1 = new System.Windows.Forms.ListViewItem("Language1");
-			System.Windows.Forms.ListViewItem listViewItem2 = new System.Windows.Forms.ListViewItem("Language2");
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmMain));
-			this.tabMain = new System.Windows.Forms.TabControl();
-			this.tabPage2 = new System.Windows.Forms.TabPage();
-			this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-			this.txtSrc = new System.Windows.Forms.TextBox();
-			this.panel1 = new System.Windows.Forms.Panel();
-			this.btnTranslate = new System.Windows.Forms.Button();
-			this.cmbDesc = new System.Windows.Forms.ComboBox();
-			this.label2 = new System.Windows.Forms.Label();
-			this.cmbSrc = new System.Windows.Forms.ComboBox();
-			this.label1 = new System.Windows.Forms.Label();
-			this.txtDesc = new System.Windows.Forms.TextBox();
-			this.panel2 = new System.Windows.Forms.Panel();
-			this.label3 = new System.Windows.Forms.Label();
-			this.tabResx = new System.Windows.Forms.TabPage();
-			this.lstResxLanguages = new System.Windows.Forms.ListView();
-			this.lblResxTranslateStatus = new System.Windows.Forms.Label();
-			this.btnStartResxTranslate = new System.Windows.Forms.Button();
-			this.barResxProgress = new System.Windows.Forms.ProgressBar();
-			this.label6 = new System.Windows.Forms.Label();
-			this.btnSelectOutputDir = new System.Windows.Forms.Button();
-			this.txtOutputDir = new System.Windows.Forms.TextBox();
-			this.label5 = new System.Windows.Forms.Label();
-			this.btnSelectResxSource = new System.Windows.Forms.Button();
-			this.cmbSourceResxLng = new System.Windows.Forms.ComboBox();
-			this.txtSourceResx = new System.Windows.Forms.TextBox();
-			this.label4 = new System.Windows.Forms.Label();
-			this.tabPage1 = new System.Windows.Forms.TabPage();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.chkExcelCreateAbsent = new System.Windows.Forms.CheckBox();
-			this.btnSelectExcel = new System.Windows.Forms.Button();
-			this.btnOpenExcel = new System.Windows.Forms.Button();
-			this.txtExcelFile = new System.Windows.Forms.TextBox();
-			this.label8 = new System.Windows.Forms.Label();
-			this.btnImportExcel = new System.Windows.Forms.Button();
-			this.cmbExcelTranslation = new System.Windows.Forms.ComboBox();
-			this.label10 = new System.Windows.Forms.Label();
-			this.cmbExcelSheets = new System.Windows.Forms.ComboBox();
-			this.label11 = new System.Windows.Forms.Label();
-			this.cmbExcelKey = new System.Windows.Forms.ComboBox();
-			this.label9 = new System.Windows.Forms.Label();
-			this.btnExcelResx = new System.Windows.Forms.Button();
-			this.txtExcelResx = new System.Windows.Forms.TextBox();
-			this.label7 = new System.Windows.Forms.Label();
-			this.lnkAbout = new System.Windows.Forms.LinkLabel();
-			this.tabBrowser = new System.Windows.Forms.TabPage();
-			this.webBrowser = new System.Windows.Forms.WebBrowser();
-			this.tabMain.SuspendLayout();
-			this.tabPage2.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-			this.splitContainer1.Panel1.SuspendLayout();
-			this.splitContainer1.Panel2.SuspendLayout();
-			this.splitContainer1.SuspendLayout();
-			this.panel1.SuspendLayout();
-			this.panel2.SuspendLayout();
-			this.tabResx.SuspendLayout();
-			this.tabPage1.SuspendLayout();
-			this.groupBox1.SuspendLayout();
-			this.tabBrowser.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// tabMain
-			// 
-			this.tabMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            System.Windows.Forms.ListViewItem listViewItem1 = new System.Windows.Forms.ListViewItem("Language1");
+            System.Windows.Forms.ListViewItem listViewItem2 = new System.Windows.Forms.ListViewItem("Language2");
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmMain));
+            this.tabMain = new System.Windows.Forms.TabControl();
+            this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.txtSrc = new System.Windows.Forms.TextBox();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.btnTranslate = new System.Windows.Forms.Button();
+            this.cmbDesc = new System.Windows.Forms.ComboBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.cmbSrc = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.txtDesc = new System.Windows.Forms.TextBox();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.label3 = new System.Windows.Forms.Label();
+            this.tabResx = new System.Windows.Forms.TabPage();
+            this.lstResxLanguages = new System.Windows.Forms.ListView();
+            this.lblResxTranslateStatus = new System.Windows.Forms.Label();
+            this.btnStartResxTranslate = new System.Windows.Forms.Button();
+            this.barResxProgress = new System.Windows.Forms.ProgressBar();
+            this.label6 = new System.Windows.Forms.Label();
+            this.btnSelectOutputDir = new System.Windows.Forms.Button();
+            this.txtOutputDir = new System.Windows.Forms.TextBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.btnSelectResxSource = new System.Windows.Forms.Button();
+            this.cmbSourceResxLng = new System.Windows.Forms.ComboBox();
+            this.txtSourceResx = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.chkExcelCreateAbsent = new System.Windows.Forms.CheckBox();
+            this.btnSelectExcel = new System.Windows.Forms.Button();
+            this.btnOpenExcel = new System.Windows.Forms.Button();
+            this.txtExcelFile = new System.Windows.Forms.TextBox();
+            this.label8 = new System.Windows.Forms.Label();
+            this.btnImportExcel = new System.Windows.Forms.Button();
+            this.cmbExcelTranslation = new System.Windows.Forms.ComboBox();
+            this.label10 = new System.Windows.Forms.Label();
+            this.cmbExcelSheets = new System.Windows.Forms.ComboBox();
+            this.label11 = new System.Windows.Forms.Label();
+            this.cmbExcelKey = new System.Windows.Forms.ComboBox();
+            this.label9 = new System.Windows.Forms.Label();
+            this.btnExcelResx = new System.Windows.Forms.Button();
+            this.txtExcelResx = new System.Windows.Forms.TextBox();
+            this.label7 = new System.Windows.Forms.Label();
+            this.tabBrowser = new System.Windows.Forms.TabPage();
+            this.webBrowser = new System.Windows.Forms.WebBrowser();
+            this.lnkAbout = new System.Windows.Forms.LinkLabel();
+            this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.radioButtonMSTranslateService = new System.Windows.Forms.RadioButton();
+            this.radioButtonGoogleTranslateService = new System.Windows.Forms.RadioButton();
+            this.tabMain.SuspendLayout();
+            this.tabPage2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.panel1.SuspendLayout();
+            this.panel2.SuspendLayout();
+            this.tabResx.SuspendLayout();
+            this.tabPage1.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.tabBrowser.SuspendLayout();
+            this.tabPage3.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tabMain
+            // 
+            this.tabMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tabMain.Controls.Add(this.tabPage2);
-			this.tabMain.Controls.Add(this.tabResx);
-			this.tabMain.Controls.Add(this.tabPage1);
-			this.tabMain.Controls.Add(this.tabBrowser);
-			this.tabMain.Location = new System.Drawing.Point(12, 12);
-			this.tabMain.Name = "tabMain";
-			this.tabMain.SelectedIndex = 0;
-			this.tabMain.Size = new System.Drawing.Size(650, 372);
-			this.tabMain.TabIndex = 0;
-			// 
-			// tabPage2
-			// 
-			this.tabPage2.Controls.Add(this.splitContainer1);
-			this.tabPage2.Location = new System.Drawing.Point(4, 22);
-			this.tabPage2.Name = "tabPage2";
-			this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-			this.tabPage2.Size = new System.Drawing.Size(642, 346);
-			this.tabPage2.TabIndex = 1;
-			this.tabPage2.Text = "Text Translator";
-			this.tabPage2.UseVisualStyleBackColor = true;
-			// 
-			// splitContainer1
-			// 
-			this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.splitContainer1.Location = new System.Drawing.Point(3, 3);
-			this.splitContainer1.Name = "splitContainer1";
-			this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
-			// 
-			// splitContainer1.Panel1
-			// 
-			this.splitContainer1.Panel1.Controls.Add(this.txtSrc);
-			this.splitContainer1.Panel1.Controls.Add(this.panel1);
-			// 
-			// splitContainer1.Panel2
-			// 
-			this.splitContainer1.Panel2.Controls.Add(this.txtDesc);
-			this.splitContainer1.Panel2.Controls.Add(this.panel2);
-			this.splitContainer1.Size = new System.Drawing.Size(636, 340);
-			this.splitContainer1.SplitterDistance = 157;
-			this.splitContainer1.TabIndex = 0;
-			// 
-			// txtSrc
-			// 
-			this.txtSrc.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.txtSrc.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
-			this.txtSrc.Location = new System.Drawing.Point(0, 31);
-			this.txtSrc.Multiline = true;
-			this.txtSrc.Name = "txtSrc";
-			this.txtSrc.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-			this.txtSrc.Size = new System.Drawing.Size(636, 126);
-			this.txtSrc.TabIndex = 1;
-			this.txtSrc.Text = "Bienvenue.";
-			// 
-			// panel1
-			// 
-			this.panel1.Controls.Add(this.btnTranslate);
-			this.panel1.Controls.Add(this.cmbDesc);
-			this.panel1.Controls.Add(this.label2);
-			this.panel1.Controls.Add(this.cmbSrc);
-			this.panel1.Controls.Add(this.label1);
-			this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
-			this.panel1.Location = new System.Drawing.Point(0, 0);
-			this.panel1.Name = "panel1";
-			this.panel1.Size = new System.Drawing.Size(636, 31);
-			this.panel1.TabIndex = 0;
-			// 
-			// btnTranslate
-			// 
-			this.btnTranslate.Location = new System.Drawing.Point(444, 5);
-			this.btnTranslate.Name = "btnTranslate";
-			this.btnTranslate.Size = new System.Drawing.Size(75, 23);
-			this.btnTranslate.TabIndex = 4;
-			this.btnTranslate.Text = "Translate";
-			this.btnTranslate.UseVisualStyleBackColor = true;
-			this.btnTranslate.Click += new System.EventHandler(this.btnTranslate_Click);
-			// 
-			// cmbDesc
-			// 
-			this.cmbDesc.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Append;
-			this.cmbDesc.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-			this.cmbDesc.FormattingEnabled = true;
-			this.cmbDesc.Location = new System.Drawing.Point(317, 5);
-			this.cmbDesc.Name = "cmbDesc";
-			this.cmbDesc.Size = new System.Drawing.Size(121, 21);
-			this.cmbDesc.TabIndex = 3;
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Location = new System.Drawing.Point(246, 8);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(69, 13);
-			this.label2.TabIndex = 2;
-			this.label2.Text = "Translate to:";
-			// 
-			// cmbSrc
-			// 
-			this.cmbSrc.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Append;
-			this.cmbSrc.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-			this.cmbSrc.FormattingEnabled = true;
-			this.cmbSrc.Location = new System.Drawing.Point(103, 5);
-			this.cmbSrc.Name = "cmbSrc";
-			this.cmbSrc.Size = new System.Drawing.Size(121, 21);
-			this.cmbSrc.TabIndex = 1;
-			// 
-			// label1
-			// 
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(3, 8);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(94, 13);
-			this.label1.TabIndex = 0;
-			this.label1.Text = "Source Language:";
-			// 
-			// txtDesc
-			// 
-			this.txtDesc.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.txtDesc.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
-			this.txtDesc.Location = new System.Drawing.Point(0, 21);
-			this.txtDesc.Multiline = true;
-			this.txtDesc.Name = "txtDesc";
-			this.txtDesc.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-			this.txtDesc.Size = new System.Drawing.Size(636, 158);
-			this.txtDesc.TabIndex = 2;
-			// 
-			// panel2
-			// 
-			this.panel2.Controls.Add(this.label3);
-			this.panel2.Dock = System.Windows.Forms.DockStyle.Top;
-			this.panel2.Location = new System.Drawing.Point(0, 0);
-			this.panel2.Name = "panel2";
-			this.panel2.Size = new System.Drawing.Size(636, 21);
-			this.panel2.TabIndex = 1;
-			// 
-			// label3
-			// 
-			this.label3.AutoSize = true;
-			this.label3.Location = new System.Drawing.Point(3, 5);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(94, 13);
-			this.label3.TabIndex = 0;
-			this.label3.Text = "Translation result:";
-			// 
-			// tabResx
-			// 
-			this.tabResx.Controls.Add(this.lstResxLanguages);
-			this.tabResx.Controls.Add(this.lblResxTranslateStatus);
-			this.tabResx.Controls.Add(this.btnStartResxTranslate);
-			this.tabResx.Controls.Add(this.barResxProgress);
-			this.tabResx.Controls.Add(this.label6);
-			this.tabResx.Controls.Add(this.btnSelectOutputDir);
-			this.tabResx.Controls.Add(this.txtOutputDir);
-			this.tabResx.Controls.Add(this.label5);
-			this.tabResx.Controls.Add(this.btnSelectResxSource);
-			this.tabResx.Controls.Add(this.cmbSourceResxLng);
-			this.tabResx.Controls.Add(this.txtSourceResx);
-			this.tabResx.Controls.Add(this.label4);
-			this.tabResx.Location = new System.Drawing.Point(4, 22);
-			this.tabResx.Name = "tabResx";
-			this.tabResx.Padding = new System.Windows.Forms.Padding(3);
-			this.tabResx.Size = new System.Drawing.Size(642, 346);
-			this.tabResx.TabIndex = 2;
-			this.tabResx.Text = "ResX Translator";
-			this.tabResx.UseVisualStyleBackColor = true;
-			// 
-			// lstResxLanguages
-			// 
-			this.lstResxLanguages.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.tabMain.Controls.Add(this.tabPage2);
+            this.tabMain.Controls.Add(this.tabResx);
+            this.tabMain.Controls.Add(this.tabPage1);
+            this.tabMain.Controls.Add(this.tabBrowser);
+            this.tabMain.Controls.Add(this.tabPage3);
+            this.tabMain.Location = new System.Drawing.Point(12, 12);
+            this.tabMain.Name = "tabMain";
+            this.tabMain.SelectedIndex = 0;
+            this.tabMain.Size = new System.Drawing.Size(650, 372);
+            this.tabMain.TabIndex = 0;
+            // 
+            // tabPage2
+            // 
+            this.tabPage2.Controls.Add(this.splitContainer1);
+            this.tabPage2.Location = new System.Drawing.Point(4, 26);
+            this.tabPage2.Name = "tabPage2";
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage2.Size = new System.Drawing.Size(642, 342);
+            this.tabPage2.TabIndex = 1;
+            this.tabPage2.Text = "Text Translator";
+            this.tabPage2.UseVisualStyleBackColor = true;
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(3, 3);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.txtSrc);
+            this.splitContainer1.Panel1.Controls.Add(this.panel1);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.txtDesc);
+            this.splitContainer1.Panel2.Controls.Add(this.panel2);
+            this.splitContainer1.Size = new System.Drawing.Size(636, 336);
+            this.splitContainer1.SplitterDistance = 155;
+            this.splitContainer1.TabIndex = 0;
+            // 
+            // txtSrc
+            // 
+            this.txtSrc.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtSrc.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
+            this.txtSrc.Location = new System.Drawing.Point(0, 31);
+            this.txtSrc.Multiline = true;
+            this.txtSrc.Name = "txtSrc";
+            this.txtSrc.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.txtSrc.Size = new System.Drawing.Size(636, 124);
+            this.txtSrc.TabIndex = 1;
+            this.txtSrc.Text = "Bienvenue.";
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.btnTranslate);
+            this.panel1.Controls.Add(this.cmbDesc);
+            this.panel1.Controls.Add(this.label2);
+            this.panel1.Controls.Add(this.cmbSrc);
+            this.panel1.Controls.Add(this.label1);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(636, 31);
+            this.panel1.TabIndex = 0;
+            // 
+            // btnTranslate
+            // 
+            this.btnTranslate.Location = new System.Drawing.Point(444, 5);
+            this.btnTranslate.Name = "btnTranslate";
+            this.btnTranslate.Size = new System.Drawing.Size(75, 23);
+            this.btnTranslate.TabIndex = 4;
+            this.btnTranslate.Text = "Translate";
+            this.btnTranslate.UseVisualStyleBackColor = true;
+            this.btnTranslate.Click += new System.EventHandler(this.btnTranslate_ClickAsync);
+            // 
+            // cmbDesc
+            // 
+            this.cmbDesc.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Append;
+            this.cmbDesc.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cmbDesc.FormattingEnabled = true;
+            this.cmbDesc.Location = new System.Drawing.Point(317, 5);
+            this.cmbDesc.Name = "cmbDesc";
+            this.cmbDesc.Size = new System.Drawing.Size(121, 25);
+            this.cmbDesc.TabIndex = 3;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(246, 8);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(85, 17);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Translate to:";
+            // 
+            // cmbSrc
+            // 
+            this.cmbSrc.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Append;
+            this.cmbSrc.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cmbSrc.FormattingEnabled = true;
+            this.cmbSrc.Location = new System.Drawing.Point(103, 5);
+            this.cmbSrc.Name = "cmbSrc";
+            this.cmbSrc.Size = new System.Drawing.Size(121, 25);
+            this.cmbSrc.TabIndex = 1;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 8);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(120, 17);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Source Language:";
+            // 
+            // txtDesc
+            // 
+            this.txtDesc.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtDesc.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
+            this.txtDesc.Location = new System.Drawing.Point(0, 21);
+            this.txtDesc.Multiline = true;
+            this.txtDesc.Name = "txtDesc";
+            this.txtDesc.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.txtDesc.Size = new System.Drawing.Size(636, 156);
+            this.txtDesc.TabIndex = 2;
+            // 
+            // panel2
+            // 
+            this.panel2.Controls.Add(this.label3);
+            this.panel2.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel2.Location = new System.Drawing.Point(0, 0);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(636, 21);
+            this.panel2.TabIndex = 1;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(3, 5);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(116, 17);
+            this.label3.TabIndex = 0;
+            this.label3.Text = "Translation result:";
+            // 
+            // tabResx
+            // 
+            this.tabResx.Controls.Add(this.lstResxLanguages);
+            this.tabResx.Controls.Add(this.lblResxTranslateStatus);
+            this.tabResx.Controls.Add(this.btnStartResxTranslate);
+            this.tabResx.Controls.Add(this.barResxProgress);
+            this.tabResx.Controls.Add(this.label6);
+            this.tabResx.Controls.Add(this.btnSelectOutputDir);
+            this.tabResx.Controls.Add(this.txtOutputDir);
+            this.tabResx.Controls.Add(this.label5);
+            this.tabResx.Controls.Add(this.btnSelectResxSource);
+            this.tabResx.Controls.Add(this.cmbSourceResxLng);
+            this.tabResx.Controls.Add(this.txtSourceResx);
+            this.tabResx.Controls.Add(this.label4);
+            this.tabResx.Location = new System.Drawing.Point(4, 26);
+            this.tabResx.Name = "tabResx";
+            this.tabResx.Padding = new System.Windows.Forms.Padding(3);
+            this.tabResx.Size = new System.Drawing.Size(642, 342);
+            this.tabResx.TabIndex = 2;
+            this.tabResx.Text = "ResX Translator";
+            this.tabResx.UseVisualStyleBackColor = true;
+            // 
+            // lstResxLanguages
+            // 
+            this.lstResxLanguages.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lstResxLanguages.CheckBoxes = true;
-			listViewItem1.StateImageIndex = 0;
-			listViewItem2.StateImageIndex = 0;
-			this.lstResxLanguages.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
+            this.lstResxLanguages.CheckBoxes = true;
+            listViewItem1.StateImageIndex = 0;
+            listViewItem2.StateImageIndex = 0;
+            this.lstResxLanguages.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
             listViewItem1,
             listViewItem2});
-			this.lstResxLanguages.Location = new System.Drawing.Point(113, 71);
-			this.lstResxLanguages.Name = "lstResxLanguages";
-			this.lstResxLanguages.Size = new System.Drawing.Size(424, 182);
-			this.lstResxLanguages.TabIndex = 12;
-			this.lstResxLanguages.UseCompatibleStateImageBehavior = false;
-			this.lstResxLanguages.View = System.Windows.Forms.View.List;
-			// 
-			// lblResxTranslateStatus
-			// 
-			this.lblResxTranslateStatus.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.lstResxLanguages.Location = new System.Drawing.Point(113, 71);
+            this.lstResxLanguages.Name = "lstResxLanguages";
+            this.lstResxLanguages.Size = new System.Drawing.Size(424, 182);
+            this.lstResxLanguages.TabIndex = 12;
+            this.lstResxLanguages.UseCompatibleStateImageBehavior = false;
+            this.lstResxLanguages.View = System.Windows.Forms.View.List;
+            // 
+            // lblResxTranslateStatus
+            // 
+            this.lblResxTranslateStatus.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblResxTranslateStatus.AutoEllipsis = true;
-			this.lblResxTranslateStatus.ForeColor = System.Drawing.Color.Black;
-			this.lblResxTranslateStatus.Location = new System.Drawing.Point(113, 289);
-			this.lblResxTranslateStatus.Name = "lblResxTranslateStatus";
-			this.lblResxTranslateStatus.Size = new System.Drawing.Size(505, 54);
-			this.lblResxTranslateStatus.TabIndex = 11;
-			// 
-			// btnStartResxTranslate
-			// 
-			this.btnStartResxTranslate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnStartResxTranslate.Location = new System.Drawing.Point(544, 259);
-			this.btnStartResxTranslate.Name = "btnStartResxTranslate";
-			this.btnStartResxTranslate.Size = new System.Drawing.Size(75, 23);
-			this.btnStartResxTranslate.TabIndex = 10;
-			this.btnStartResxTranslate.Text = "Translate";
-			this.btnStartResxTranslate.UseVisualStyleBackColor = true;
-			this.btnStartResxTranslate.Click += new System.EventHandler(this.btnStartResxTranslate_Click);
-			// 
-			// barResxProgress
-			// 
-			this.barResxProgress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.lblResxTranslateStatus.AutoEllipsis = true;
+            this.lblResxTranslateStatus.ForeColor = System.Drawing.Color.Black;
+            this.lblResxTranslateStatus.Location = new System.Drawing.Point(113, 289);
+            this.lblResxTranslateStatus.Name = "lblResxTranslateStatus";
+            this.lblResxTranslateStatus.Size = new System.Drawing.Size(505, 54);
+            this.lblResxTranslateStatus.TabIndex = 11;
+            // 
+            // btnStartResxTranslate
+            // 
+            this.btnStartResxTranslate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnStartResxTranslate.Location = new System.Drawing.Point(544, 259);
+            this.btnStartResxTranslate.Name = "btnStartResxTranslate";
+            this.btnStartResxTranslate.Size = new System.Drawing.Size(75, 23);
+            this.btnStartResxTranslate.TabIndex = 10;
+            this.btnStartResxTranslate.Text = "Translate";
+            this.btnStartResxTranslate.UseVisualStyleBackColor = true;
+            this.btnStartResxTranslate.Click += new System.EventHandler(this.btnStartResxTranslate_Click);
+            // 
+            // barResxProgress
+            // 
+            this.barResxProgress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.barResxProgress.Location = new System.Drawing.Point(113, 259);
-			this.barResxProgress.Name = "barResxProgress";
-			this.barResxProgress.Size = new System.Drawing.Size(424, 23);
-			this.barResxProgress.TabIndex = 9;
-			// 
-			// label6
-			// 
-			this.label6.AutoSize = true;
-			this.label6.Location = new System.Drawing.Point(7, 73);
-			this.label6.Name = "label6";
-			this.label6.Size = new System.Drawing.Size(100, 13);
-			this.label6.TabIndex = 8;
-			this.label6.Text = "Output Languages:";
-			// 
-			// btnSelectOutputDir
-			// 
-			this.btnSelectOutputDir.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnSelectOutputDir.Location = new System.Drawing.Point(543, 42);
-			this.btnSelectOutputDir.Name = "btnSelectOutputDir";
-			this.btnSelectOutputDir.Size = new System.Drawing.Size(75, 23);
-			this.btnSelectOutputDir.TabIndex = 6;
-			this.btnSelectOutputDir.Text = "Select";
-			this.btnSelectOutputDir.UseVisualStyleBackColor = true;
-			this.btnSelectOutputDir.Click += new System.EventHandler(this.btnSelectOutputDir_Click);
-			// 
-			// txtOutputDir
-			// 
-			this.txtOutputDir.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.barResxProgress.Location = new System.Drawing.Point(113, 259);
+            this.barResxProgress.Name = "barResxProgress";
+            this.barResxProgress.Size = new System.Drawing.Size(424, 23);
+            this.barResxProgress.TabIndex = 9;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(7, 73);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(127, 17);
+            this.label6.TabIndex = 8;
+            this.label6.Text = "Output Languages:";
+            // 
+            // btnSelectOutputDir
+            // 
+            this.btnSelectOutputDir.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSelectOutputDir.Location = new System.Drawing.Point(543, 42);
+            this.btnSelectOutputDir.Name = "btnSelectOutputDir";
+            this.btnSelectOutputDir.Size = new System.Drawing.Size(75, 23);
+            this.btnSelectOutputDir.TabIndex = 6;
+            this.btnSelectOutputDir.Text = "Select";
+            this.btnSelectOutputDir.UseVisualStyleBackColor = true;
+            this.btnSelectOutputDir.Click += new System.EventHandler(this.btnSelectOutputDir_Click);
+            // 
+            // txtOutputDir
+            // 
+            this.txtOutputDir.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtOutputDir.Location = new System.Drawing.Point(113, 44);
-			this.txtOutputDir.Name = "txtOutputDir";
-			this.txtOutputDir.Size = new System.Drawing.Size(424, 21);
-			this.txtOutputDir.TabIndex = 5;
-			// 
-			// label5
-			// 
-			this.label5.AutoSize = true;
-			this.label5.Location = new System.Drawing.Point(15, 47);
-			this.label5.Name = "label5";
-			this.label5.Size = new System.Drawing.Size(92, 13);
-			this.label5.TabIndex = 4;
-			this.label5.Text = "Output Directory:";
-			// 
-			// btnSelectResxSource
-			// 
-			this.btnSelectResxSource.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnSelectResxSource.Location = new System.Drawing.Point(543, 15);
-			this.btnSelectResxSource.Name = "btnSelectResxSource";
-			this.btnSelectResxSource.Size = new System.Drawing.Size(75, 23);
-			this.btnSelectResxSource.TabIndex = 3;
-			this.btnSelectResxSource.Text = "Select";
-			this.btnSelectResxSource.UseVisualStyleBackColor = true;
-			this.btnSelectResxSource.Click += new System.EventHandler(this.btnSelectResxSource_Click);
-			// 
-			// cmbSourceResxLng
-			// 
-			this.cmbSourceResxLng.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.cmbSourceResxLng.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Append;
-			this.cmbSourceResxLng.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-			this.cmbSourceResxLng.FormattingEnabled = true;
-			this.cmbSourceResxLng.Location = new System.Drawing.Point(416, 17);
-			this.cmbSourceResxLng.Name = "cmbSourceResxLng";
-			this.cmbSourceResxLng.Size = new System.Drawing.Size(121, 21);
-			this.cmbSourceResxLng.TabIndex = 2;
-			// 
-			// txtSourceResx
-			// 
-			this.txtSourceResx.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txtOutputDir.Location = new System.Drawing.Point(113, 44);
+            this.txtOutputDir.Name = "txtOutputDir";
+            this.txtOutputDir.Size = new System.Drawing.Size(424, 24);
+            this.txtOutputDir.TabIndex = 5;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(15, 47);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(118, 17);
+            this.label5.TabIndex = 4;
+            this.label5.Text = "Output Directory:";
+            // 
+            // btnSelectResxSource
+            // 
+            this.btnSelectResxSource.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSelectResxSource.Location = new System.Drawing.Point(543, 15);
+            this.btnSelectResxSource.Name = "btnSelectResxSource";
+            this.btnSelectResxSource.Size = new System.Drawing.Size(75, 23);
+            this.btnSelectResxSource.TabIndex = 3;
+            this.btnSelectResxSource.Text = "Select";
+            this.btnSelectResxSource.UseVisualStyleBackColor = true;
+            this.btnSelectResxSource.Click += new System.EventHandler(this.btnSelectResxSource_Click);
+            // 
+            // cmbSourceResxLng
+            // 
+            this.cmbSourceResxLng.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmbSourceResxLng.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Append;
+            this.cmbSourceResxLng.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cmbSourceResxLng.FormattingEnabled = true;
+            this.cmbSourceResxLng.Location = new System.Drawing.Point(416, 17);
+            this.cmbSourceResxLng.Name = "cmbSourceResxLng";
+            this.cmbSourceResxLng.Size = new System.Drawing.Size(121, 25);
+            this.cmbSourceResxLng.TabIndex = 2;
+            // 
+            // txtSourceResx
+            // 
+            this.txtSourceResx.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtSourceResx.Location = new System.Drawing.Point(113, 17);
-			this.txtSourceResx.Name = "txtSourceResx";
-			this.txtSourceResx.ReadOnly = true;
-			this.txtSourceResx.Size = new System.Drawing.Size(297, 21);
-			this.txtSourceResx.TabIndex = 1;
-			// 
-			// label4
-			// 
-			this.label4.AutoSize = true;
-			this.label4.Location = new System.Drawing.Point(17, 20);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(90, 13);
-			this.label4.TabIndex = 0;
-			this.label4.Text = "Source Resx File:";
-			// 
-			// tabPage1
-			// 
-			this.tabPage1.Controls.Add(this.groupBox1);
-			this.tabPage1.Controls.Add(this.btnExcelResx);
-			this.tabPage1.Controls.Add(this.txtExcelResx);
-			this.tabPage1.Controls.Add(this.label7);
-			this.tabPage1.Location = new System.Drawing.Point(4, 22);
-			this.tabPage1.Name = "tabPage1";
-			this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-			this.tabPage1.Size = new System.Drawing.Size(642, 346);
-			this.tabPage1.TabIndex = 3;
-			this.tabPage1.Text = "Excel Import";
-			this.tabPage1.UseVisualStyleBackColor = true;
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Controls.Add(this.chkExcelCreateAbsent);
-			this.groupBox1.Controls.Add(this.btnSelectExcel);
-			this.groupBox1.Controls.Add(this.btnOpenExcel);
-			this.groupBox1.Controls.Add(this.txtExcelFile);
-			this.groupBox1.Controls.Add(this.label8);
-			this.groupBox1.Controls.Add(this.btnImportExcel);
-			this.groupBox1.Controls.Add(this.cmbExcelTranslation);
-			this.groupBox1.Controls.Add(this.label10);
-			this.groupBox1.Controls.Add(this.cmbExcelSheets);
-			this.groupBox1.Controls.Add(this.label11);
-			this.groupBox1.Controls.Add(this.cmbExcelKey);
-			this.groupBox1.Controls.Add(this.label9);
-			this.groupBox1.Location = new System.Drawing.Point(6, 44);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Size = new System.Drawing.Size(630, 153);
-			this.groupBox1.TabIndex = 4;
-			this.groupBox1.TabStop = false;
-			this.groupBox1.Text = "Import";
-			// 
-			// chkExcelCreateAbsent
-			// 
-			this.chkExcelCreateAbsent.AutoSize = true;
-			this.chkExcelCreateAbsent.Checked = true;
-			this.chkExcelCreateAbsent.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chkExcelCreateAbsent.Location = new System.Drawing.Point(107, 128);
-			this.chkExcelCreateAbsent.Name = "chkExcelCreateAbsent";
-			this.chkExcelCreateAbsent.Size = new System.Drawing.Size(167, 17);
-			this.chkExcelCreateAbsent.TabIndex = 9;
-			this.chkExcelCreateAbsent.Text = "Create absent language keys";
-			this.chkExcelCreateAbsent.UseVisualStyleBackColor = true;
-			// 
-			// btnSelectExcel
-			// 
-			this.btnSelectExcel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnSelectExcel.Location = new System.Drawing.Point(537, 18);
-			this.btnSelectExcel.Name = "btnSelectExcel";
-			this.btnSelectExcel.Size = new System.Drawing.Size(75, 23);
-			this.btnSelectExcel.TabIndex = 3;
-			this.btnSelectExcel.Text = "Select";
-			this.btnSelectExcel.UseVisualStyleBackColor = true;
-			this.btnSelectExcel.Click += new System.EventHandler(this.btnSelectExcel_Click);
-			// 
-			// btnOpenExcel
-			// 
-			this.btnOpenExcel.Location = new System.Drawing.Point(263, 46);
-			this.btnOpenExcel.Name = "btnOpenExcel";
-			this.btnOpenExcel.Size = new System.Drawing.Size(75, 23);
-			this.btnOpenExcel.TabIndex = 1;
-			this.btnOpenExcel.Text = "Open Excel";
-			this.btnOpenExcel.UseVisualStyleBackColor = true;
-			this.btnOpenExcel.Click += new System.EventHandler(this.btnOpenExcel_Click);
-			// 
-			// txtExcelFile
-			// 
-			this.txtExcelFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txtSourceResx.Location = new System.Drawing.Point(113, 17);
+            this.txtSourceResx.Name = "txtSourceResx";
+            this.txtSourceResx.ReadOnly = true;
+            this.txtSourceResx.Size = new System.Drawing.Size(297, 24);
+            this.txtSourceResx.TabIndex = 1;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(17, 20);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(112, 17);
+            this.label4.TabIndex = 0;
+            this.label4.Text = "Source Resx File:";
+            // 
+            // tabPage1
+            // 
+            this.tabPage1.Controls.Add(this.groupBox1);
+            this.tabPage1.Controls.Add(this.btnExcelResx);
+            this.tabPage1.Controls.Add(this.txtExcelResx);
+            this.tabPage1.Controls.Add(this.label7);
+            this.tabPage1.Location = new System.Drawing.Point(4, 26);
+            this.tabPage1.Name = "tabPage1";
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage1.Size = new System.Drawing.Size(642, 342);
+            this.tabPage1.TabIndex = 3;
+            this.tabPage1.Text = "Excel Import";
+            this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.chkExcelCreateAbsent);
+            this.groupBox1.Controls.Add(this.btnSelectExcel);
+            this.groupBox1.Controls.Add(this.btnOpenExcel);
+            this.groupBox1.Controls.Add(this.txtExcelFile);
+            this.groupBox1.Controls.Add(this.label8);
+            this.groupBox1.Controls.Add(this.btnImportExcel);
+            this.groupBox1.Controls.Add(this.cmbExcelTranslation);
+            this.groupBox1.Controls.Add(this.label10);
+            this.groupBox1.Controls.Add(this.cmbExcelSheets);
+            this.groupBox1.Controls.Add(this.label11);
+            this.groupBox1.Controls.Add(this.cmbExcelKey);
+            this.groupBox1.Controls.Add(this.label9);
+            this.groupBox1.Location = new System.Drawing.Point(6, 44);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(630, 153);
+            this.groupBox1.TabIndex = 4;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Import";
+            // 
+            // chkExcelCreateAbsent
+            // 
+            this.chkExcelCreateAbsent.AutoSize = true;
+            this.chkExcelCreateAbsent.Checked = true;
+            this.chkExcelCreateAbsent.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkExcelCreateAbsent.Location = new System.Drawing.Point(107, 128);
+            this.chkExcelCreateAbsent.Name = "chkExcelCreateAbsent";
+            this.chkExcelCreateAbsent.Size = new System.Drawing.Size(206, 21);
+            this.chkExcelCreateAbsent.TabIndex = 9;
+            this.chkExcelCreateAbsent.Text = "Create absent language keys";
+            this.chkExcelCreateAbsent.UseVisualStyleBackColor = true;
+            // 
+            // btnSelectExcel
+            // 
+            this.btnSelectExcel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSelectExcel.Location = new System.Drawing.Point(537, 18);
+            this.btnSelectExcel.Name = "btnSelectExcel";
+            this.btnSelectExcel.Size = new System.Drawing.Size(75, 23);
+            this.btnSelectExcel.TabIndex = 3;
+            this.btnSelectExcel.Text = "Select";
+            this.btnSelectExcel.UseVisualStyleBackColor = true;
+            this.btnSelectExcel.Click += new System.EventHandler(this.btnSelectExcel_Click);
+            // 
+            // btnOpenExcel
+            // 
+            this.btnOpenExcel.Location = new System.Drawing.Point(263, 46);
+            this.btnOpenExcel.Name = "btnOpenExcel";
+            this.btnOpenExcel.Size = new System.Drawing.Size(75, 23);
+            this.btnOpenExcel.TabIndex = 1;
+            this.btnOpenExcel.Text = "Open Excel";
+            this.btnOpenExcel.UseVisualStyleBackColor = true;
+            this.btnOpenExcel.Click += new System.EventHandler(this.btnOpenExcel_Click);
+            // 
+            // txtExcelFile
+            // 
+            this.txtExcelFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtExcelFile.Location = new System.Drawing.Point(107, 20);
-			this.txtExcelFile.Name = "txtExcelFile";
-			this.txtExcelFile.Size = new System.Drawing.Size(424, 21);
-			this.txtExcelFile.TabIndex = 2;
-			// 
-			// label8
-			// 
-			this.label8.AutoSize = true;
-			this.label8.Location = new System.Drawing.Point(46, 23);
-			this.label8.Name = "label8";
-			this.label8.Size = new System.Drawing.Size(55, 13);
-			this.label8.TabIndex = 8;
-			this.label8.Text = "Excel File:";
-			// 
-			// btnImportExcel
-			// 
-			this.btnImportExcel.Enabled = false;
-			this.btnImportExcel.Location = new System.Drawing.Point(263, 100);
-			this.btnImportExcel.Name = "btnImportExcel";
-			this.btnImportExcel.Size = new System.Drawing.Size(75, 23);
-			this.btnImportExcel.TabIndex = 4;
-			this.btnImportExcel.Text = "Import";
-			this.btnImportExcel.UseVisualStyleBackColor = true;
-			this.btnImportExcel.Click += new System.EventHandler(this.btnImportExcel_Click);
-			// 
-			// cmbExcelTranslation
-			// 
-			this.cmbExcelTranslation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cmbExcelTranslation.FormattingEnabled = true;
-			this.cmbExcelTranslation.Location = new System.Drawing.Point(107, 101);
-			this.cmbExcelTranslation.Name = "cmbExcelTranslation";
-			this.cmbExcelTranslation.Size = new System.Drawing.Size(150, 21);
-			this.cmbExcelTranslation.TabIndex = 3;
-			// 
-			// label10
-			// 
-			this.label10.AutoSize = true;
-			this.label10.Location = new System.Drawing.Point(-1, 104);
-			this.label10.Name = "label10";
-			this.label10.Size = new System.Drawing.Size(102, 13);
-			this.label10.TabIndex = 8;
-			this.label10.Text = "Translation Column:";
-			// 
-			// cmbExcelSheets
-			// 
-			this.cmbExcelSheets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cmbExcelSheets.FormattingEnabled = true;
-			this.cmbExcelSheets.Location = new System.Drawing.Point(107, 47);
-			this.cmbExcelSheets.Name = "cmbExcelSheets";
-			this.cmbExcelSheets.Size = new System.Drawing.Size(150, 21);
-			this.cmbExcelSheets.TabIndex = 0;
-			this.cmbExcelSheets.SelectedIndexChanged += new System.EventHandler(this.cmbExcelSheets_SelectedIndexChanged);
-			// 
-			// label11
-			// 
-			this.label11.AutoSize = true;
-			this.label11.Location = new System.Drawing.Point(34, 50);
-			this.label11.Name = "label11";
-			this.label11.Size = new System.Drawing.Size(69, 13);
-			this.label11.TabIndex = 8;
-			this.label11.Text = "Sheet Name:";
-			// 
-			// cmbExcelKey
-			// 
-			this.cmbExcelKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cmbExcelKey.FormattingEnabled = true;
-			this.cmbExcelKey.Location = new System.Drawing.Point(107, 74);
-			this.cmbExcelKey.Name = "cmbExcelKey";
-			this.cmbExcelKey.Size = new System.Drawing.Size(150, 21);
-			this.cmbExcelKey.TabIndex = 2;
-			// 
-			// label9
-			// 
-			this.label9.AutoSize = true;
-			this.label9.Location = new System.Drawing.Point(34, 77);
-			this.label9.Name = "label9";
-			this.label9.Size = new System.Drawing.Size(67, 13);
-			this.label9.TabIndex = 8;
-			this.label9.Text = "Key Column:";
-			// 
-			// btnExcelResx
-			// 
-			this.btnExcelResx.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnExcelResx.Location = new System.Drawing.Point(543, 15);
-			this.btnExcelResx.Name = "btnExcelResx";
-			this.btnExcelResx.Size = new System.Drawing.Size(75, 23);
-			this.btnExcelResx.TabIndex = 1;
-			this.btnExcelResx.Text = "Select";
-			this.btnExcelResx.UseVisualStyleBackColor = true;
-			this.btnExcelResx.Click += new System.EventHandler(this.btnExcelResx_Click);
-			// 
-			// txtExcelResx
-			// 
-			this.txtExcelResx.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txtExcelFile.Location = new System.Drawing.Point(107, 20);
+            this.txtExcelFile.Name = "txtExcelFile";
+            this.txtExcelFile.Size = new System.Drawing.Size(424, 24);
+            this.txtExcelFile.TabIndex = 2;
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(46, 23);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(67, 17);
+            this.label8.TabIndex = 8;
+            this.label8.Text = "Excel File:";
+            // 
+            // btnImportExcel
+            // 
+            this.btnImportExcel.Enabled = false;
+            this.btnImportExcel.Location = new System.Drawing.Point(263, 100);
+            this.btnImportExcel.Name = "btnImportExcel";
+            this.btnImportExcel.Size = new System.Drawing.Size(75, 23);
+            this.btnImportExcel.TabIndex = 4;
+            this.btnImportExcel.Text = "Import";
+            this.btnImportExcel.UseVisualStyleBackColor = true;
+            this.btnImportExcel.Click += new System.EventHandler(this.btnImportExcel_Click);
+            // 
+            // cmbExcelTranslation
+            // 
+            this.cmbExcelTranslation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbExcelTranslation.FormattingEnabled = true;
+            this.cmbExcelTranslation.Location = new System.Drawing.Point(107, 101);
+            this.cmbExcelTranslation.Name = "cmbExcelTranslation";
+            this.cmbExcelTranslation.Size = new System.Drawing.Size(150, 25);
+            this.cmbExcelTranslation.TabIndex = 3;
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(-1, 104);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(130, 17);
+            this.label10.TabIndex = 8;
+            this.label10.Text = "Translation Column:";
+            // 
+            // cmbExcelSheets
+            // 
+            this.cmbExcelSheets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbExcelSheets.FormattingEnabled = true;
+            this.cmbExcelSheets.Location = new System.Drawing.Point(107, 47);
+            this.cmbExcelSheets.Name = "cmbExcelSheets";
+            this.cmbExcelSheets.Size = new System.Drawing.Size(150, 25);
+            this.cmbExcelSheets.TabIndex = 0;
+            this.cmbExcelSheets.SelectedIndexChanged += new System.EventHandler(this.cmbExcelSheets_SelectedIndexChanged);
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.Location = new System.Drawing.Point(34, 50);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(87, 17);
+            this.label11.TabIndex = 8;
+            this.label11.Text = "Sheet Name:";
+            // 
+            // cmbExcelKey
+            // 
+            this.cmbExcelKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbExcelKey.FormattingEnabled = true;
+            this.cmbExcelKey.Location = new System.Drawing.Point(107, 74);
+            this.cmbExcelKey.Name = "cmbExcelKey";
+            this.cmbExcelKey.Size = new System.Drawing.Size(150, 25);
+            this.cmbExcelKey.TabIndex = 2;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(34, 77);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(87, 17);
+            this.label9.TabIndex = 8;
+            this.label9.Text = "Key Column:";
+            // 
+            // btnExcelResx
+            // 
+            this.btnExcelResx.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnExcelResx.Location = new System.Drawing.Point(543, 15);
+            this.btnExcelResx.Name = "btnExcelResx";
+            this.btnExcelResx.Size = new System.Drawing.Size(75, 23);
+            this.btnExcelResx.TabIndex = 1;
+            this.btnExcelResx.Text = "Select";
+            this.btnExcelResx.UseVisualStyleBackColor = true;
+            this.btnExcelResx.Click += new System.EventHandler(this.btnExcelResx_Click);
+            // 
+            // txtExcelResx
+            // 
+            this.txtExcelResx.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtExcelResx.Location = new System.Drawing.Point(113, 17);
-			this.txtExcelResx.Name = "txtExcelResx";
-			this.txtExcelResx.ReadOnly = true;
-			this.txtExcelResx.Size = new System.Drawing.Size(424, 21);
-			this.txtExcelResx.TabIndex = 0;
-			// 
-			// label7
-			// 
-			this.label7.AutoSize = true;
-			this.label7.Location = new System.Drawing.Point(53, 20);
-			this.label7.Name = "label7";
-			this.label7.Size = new System.Drawing.Size(54, 13);
-			this.label7.TabIndex = 4;
-			this.label7.Text = "Resx File:";
-			// 
-			// lnkAbout
-			// 
-			this.lnkAbout.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.lnkAbout.AutoSize = true;
-			this.lnkAbout.Location = new System.Drawing.Point(621, 13);
-			this.lnkAbout.Name = "lnkAbout";
-			this.lnkAbout.Size = new System.Drawing.Size(36, 13);
-			this.lnkAbout.TabIndex = 3;
-			this.lnkAbout.TabStop = true;
-			this.lnkAbout.Text = "About";
-			this.lnkAbout.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkAbout_LinkClicked);
-			// 
-			// tabBrowser
-			// 
-			this.tabBrowser.Controls.Add(this.webBrowser);
-			this.tabBrowser.Location = new System.Drawing.Point(4, 22);
-			this.tabBrowser.Name = "tabBrowser";
-			this.tabBrowser.Padding = new System.Windows.Forms.Padding(3);
-			this.tabBrowser.Size = new System.Drawing.Size(642, 346);
-			this.tabBrowser.TabIndex = 4;
-			this.tabBrowser.Text = "Google Translator";
-			this.tabBrowser.UseVisualStyleBackColor = true;
-			// 
-			// webBrowser
-			// 
-			this.webBrowser.AllowWebBrowserDrop = false;
-			this.webBrowser.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.webBrowser.IsWebBrowserContextMenuEnabled = false;
-			this.webBrowser.Location = new System.Drawing.Point(3, 3);
-			this.webBrowser.MinimumSize = new System.Drawing.Size(20, 20);
-			this.webBrowser.Name = "webBrowser";
-			this.webBrowser.Size = new System.Drawing.Size(636, 340);
-			this.webBrowser.TabIndex = 0;
-			this.webBrowser.Url = new System.Uri("https://translate.google.com/", System.UriKind.Absolute);
-			this.webBrowser.DocumentCompleted += new System.Windows.Forms.WebBrowserDocumentCompletedEventHandler(this.webBrowser_DocumentCompleted);
-			// 
-			// frmMain
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(674, 396);
-			this.Controls.Add(this.lnkAbout);
-			this.Controls.Add(this.tabMain);
-			this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MinimumSize = new System.Drawing.Size(500, 400);
-			this.Name = "frmMain";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-			this.Text = "Auto Resource Translator";
-			this.Load += new System.EventHandler(this.frmMain_Load);
-			this.tabMain.ResumeLayout(false);
-			this.tabPage2.ResumeLayout(false);
-			this.splitContainer1.Panel1.ResumeLayout(false);
-			this.splitContainer1.Panel1.PerformLayout();
-			this.splitContainer1.Panel2.ResumeLayout(false);
-			this.splitContainer1.Panel2.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-			this.splitContainer1.ResumeLayout(false);
-			this.panel1.ResumeLayout(false);
-			this.panel1.PerformLayout();
-			this.panel2.ResumeLayout(false);
-			this.panel2.PerformLayout();
-			this.tabResx.ResumeLayout(false);
-			this.tabResx.PerformLayout();
-			this.tabPage1.ResumeLayout(false);
-			this.tabPage1.PerformLayout();
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox1.PerformLayout();
-			this.tabBrowser.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.txtExcelResx.Location = new System.Drawing.Point(113, 17);
+            this.txtExcelResx.Name = "txtExcelResx";
+            this.txtExcelResx.ReadOnly = true;
+            this.txtExcelResx.Size = new System.Drawing.Size(424, 24);
+            this.txtExcelResx.TabIndex = 0;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(53, 20);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(65, 17);
+            this.label7.TabIndex = 4;
+            this.label7.Text = "Resx File:";
+            // 
+            // tabBrowser
+            // 
+            this.tabBrowser.Controls.Add(this.webBrowser);
+            this.tabBrowser.Location = new System.Drawing.Point(4, 26);
+            this.tabBrowser.Name = "tabBrowser";
+            this.tabBrowser.Padding = new System.Windows.Forms.Padding(3);
+            this.tabBrowser.Size = new System.Drawing.Size(642, 342);
+            this.tabBrowser.TabIndex = 4;
+            this.tabBrowser.Text = "Google Translator";
+            this.tabBrowser.UseVisualStyleBackColor = true;
+            // 
+            // webBrowser
+            // 
+            this.webBrowser.AllowWebBrowserDrop = false;
+            this.webBrowser.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.webBrowser.IsWebBrowserContextMenuEnabled = false;
+            this.webBrowser.Location = new System.Drawing.Point(3, 3);
+            this.webBrowser.MinimumSize = new System.Drawing.Size(20, 20);
+            this.webBrowser.Name = "webBrowser";
+            this.webBrowser.Size = new System.Drawing.Size(636, 336);
+            this.webBrowser.TabIndex = 0;
+            this.webBrowser.Url = new System.Uri("https://translate.google.com/", System.UriKind.Absolute);
+            this.webBrowser.DocumentCompleted += new System.Windows.Forms.WebBrowserDocumentCompletedEventHandler(this.webBrowser_DocumentCompleted);
+            // 
+            // lnkAbout
+            // 
+            this.lnkAbout.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lnkAbout.AutoSize = true;
+            this.lnkAbout.Location = new System.Drawing.Point(621, 13);
+            this.lnkAbout.Name = "lnkAbout";
+            this.lnkAbout.Size = new System.Drawing.Size(45, 17);
+            this.lnkAbout.TabIndex = 3;
+            this.lnkAbout.TabStop = true;
+            this.lnkAbout.Text = "About";
+            this.lnkAbout.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkAbout_LinkClicked);
+            // 
+            // tabPage3
+            // 
+            this.tabPage3.Controls.Add(this.groupBox2);
+            this.tabPage3.Location = new System.Drawing.Point(4, 26);
+            this.tabPage3.Name = "tabPage3";
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage3.Size = new System.Drawing.Size(642, 342);
+            this.tabPage3.TabIndex = 5;
+            this.tabPage3.Text = "Translate Service";
+            this.tabPage3.UseVisualStyleBackColor = true;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.radioButtonGoogleTranslateService);
+            this.groupBox2.Controls.Add(this.radioButtonMSTranslateService);
+            this.groupBox2.Location = new System.Drawing.Point(6, 6);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(630, 78);
+            this.groupBox2.TabIndex = 0;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Translate Service Selection";
+            // 
+            // radioButtonMSTranslateService
+            // 
+            this.radioButtonMSTranslateService.AutoSize = true;
+            this.radioButtonMSTranslateService.Location = new System.Drawing.Point(6, 23);
+            this.radioButtonMSTranslateService.Name = "radioButtonMSTranslateService";
+            this.radioButtonMSTranslateService.Size = new System.Drawing.Size(269, 21);
+            this.radioButtonMSTranslateService.TabIndex = 0;
+            this.radioButtonMSTranslateService.Text = "Microsoft Cognitive Translations Service";
+            this.radioButtonMSTranslateService.UseVisualStyleBackColor = true;
+            this.radioButtonMSTranslateService.CheckedChanged += new System.EventHandler(this.radioButtonMSTranslateService_CheckedChanged);
+            // 
+            // radioButtonGoogleTranslateService
+            // 
+            this.radioButtonGoogleTranslateService.AutoSize = true;
+            this.radioButtonGoogleTranslateService.Checked = true;
+            this.radioButtonGoogleTranslateService.Location = new System.Drawing.Point(6, 50);
+            this.radioButtonGoogleTranslateService.Name = "radioButtonGoogleTranslateService";
+            this.radioButtonGoogleTranslateService.Size = new System.Drawing.Size(189, 21);
+            this.radioButtonGoogleTranslateService.TabIndex = 1;
+            this.radioButtonGoogleTranslateService.TabStop = true;
+            this.radioButtonGoogleTranslateService.Text = "Google Translation Service";
+            this.radioButtonGoogleTranslateService.UseVisualStyleBackColor = true;
+            this.radioButtonGoogleTranslateService.CheckedChanged += new System.EventHandler(this.radioButtonGoogleTranslateService_CheckedChanged);
+            // 
+            // frmMain
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(674, 396);
+            this.Controls.Add(this.lnkAbout);
+            this.Controls.Add(this.tabMain);
+            this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(178)));
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MinimumSize = new System.Drawing.Size(500, 400);
+            this.Name = "frmMain";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Auto Resource Translator";
+            this.Load += new System.EventHandler(this.frmMain_Load);
+            this.tabMain.ResumeLayout(false);
+            this.tabPage2.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            this.panel2.ResumeLayout(false);
+            this.panel2.PerformLayout();
+            this.tabResx.ResumeLayout(false);
+            this.tabResx.PerformLayout();
+            this.tabPage1.ResumeLayout(false);
+            this.tabPage1.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.tabBrowser.ResumeLayout(false);
+            this.tabPage3.ResumeLayout(false);
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -693,6 +749,10 @@
 		private System.Windows.Forms.CheckBox chkExcelCreateAbsent;
 		private System.Windows.Forms.TabPage tabBrowser;
 		private System.Windows.Forms.WebBrowser webBrowser;
-	}
+        private System.Windows.Forms.TabPage tabPage3;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.RadioButton radioButtonGoogleTranslateService;
+        private System.Windows.Forms.RadioButton radioButtonMSTranslateService;
+    }
 }
 

--- a/AutoResxTranslator/frmMain.cs
+++ b/AutoResxTranslator/frmMain.cs
@@ -19,700 +19,737 @@ using System.Xml;
 
 namespace AutoResxTranslator
 {
-	public partial class frmMain : Form
-	{
-		public frmMain()
-		{
-			InitializeComponent();
-		}
-
-		private readonly Dictionary<string, string> _languages =
-			new Dictionary<string, string>
-			{
-				{"auto", "(Detect)"},
-				{"af", "Afrikaans"},
-				{"sq", "Albanian"},
-				{"ar", "Arabic"},
-				{"hy", "Armenian"},
-				{"az", "Azerbaijani"},
-				{"eu", "Basque"},
-				{"be", "Belarusian"},
-				{"bn", "Bengali"},
-				{"bg", "Bulgarian"},
-				{"ca", "Catalan"},
-				{"zh-CN", "Chinese (Simplified)"},
-				{"zh-TW", "Chinese (Traditional)"},
-				{"hr", "Croatian"},
-				{"cs", "Czech"},
-				{"da", "Danish"},
-				{"nl", "Dutch"},
-				{"en", "English"},
-				{"eo", "Esperanto"},
-				{"et", "Estonian"},
-				{"tl", "Filipino"},
-				{"fi", "Finnish"},
-				{"fr", "French"},
-				{"gl", "Galician"},
-				{"ka", "Georgian"},
-				{"de", "German"},
-				{"el", "Greek"},
-				{"gu", "Gujarati"},
-				{"ht", "Haitian Creole"},
-				{"iw", "Hebrew"},
-				{"hi", "Hindi"},
-				{"hu", "Hungarian"},
-				{"is", "Icelandic"},
-				{"id", "Indonesian"},
-				{"ga", "Irish"},
-				{"it", "Italian"},
-				{"ja", "Japanese"},
-				{"kn", "Kannada"},
-				{"km", "Khmer"},
-				{"ko", "Korean"},
-				{"lo", "Lao"},
-				{"la", "Latin"},
-				{"lv", "Latvian"},
-				{"lt", "Lithuanian"},
-				{"mk", "Macedonian"},
-				{"ms", "Malay"},
-				{"mt", "Maltese"},
-				{"no", "Norwegian"},
-				{"fa", "Persian"},
-				{"pl", "Polish"},
-				{"pt", "Portuguese"},
-				{"ro", "Romanian"},
-				{"ru", "Russian"},
-				{"sr", "Serbian"},
-				{"sk", "Slovak"},
-				{"sl", "Slovenian"},
-				{"es", "Spanish"},
-				{"sw", "Swahili"},
-				{"sv", "Swedish"},
-				{"ta", "Tamil"},
-				{"te", "Telugu"},
-				{"th", "Thai"},
-				{"tr", "Turkish"},
-				{"uk", "Ukrainian"},
-				{"ur", "Urdu"},
-				{"vi", "Vietnamese"},
-				{"cy", "Welsh"},
-				{"yi", "Yiddish"}
-			};
-
-
-		void FillComboBoxes()
-		{
-			cmbSrc.DisplayMember = "Value";
-			cmbSrc.ValueMember = "Key";
-
-			cmbDesc.DisplayMember = "Value";
-			cmbDesc.ValueMember = "Key";
-			lstResxLanguages.Items.Clear();
-
-			foreach (var k in _languages)
-			{
-				cmbSrc.Items.Add(k);
-				if (k.Key == "auto")
-					continue;
-				cmbDesc.Items.Add(k);
-				cmbSourceResxLng.Items.Add(k);
-				lstResxLanguages.Items.Add(k.Key, k.Value, -1);
-			}
-			cmbSrc.SelectedIndex = 0;
-			cmbDesc.Text = "English";
-		}
-
-		void SetResult(string result)
-		{
-			if (this.InvokeRequired)
-			{
-				this.BeginInvoke(new Action<string>(SetResult), result);
-				return;
-			}
-			else
-			{
-				txtDesc.Text = result;
-			}
-		}
-
-		void IsBusy(bool isbusy)
-		{
-			if (this.InvokeRequired)
-			{
-				this.BeginInvoke(new Action<bool>(IsBusy), isbusy);
-				return;
-			}
-			else
-			{
-				tabMain.Enabled = !isbusy;
-			}
-		}
-
-
-		string ReadLanguageName(string fileName)
-		{
-			try
-			{
-				fileName = Path.GetFileName(fileName);
-				var match = Regex.Match(fileName, @".+\.(?<lng>.+)\.resx");
-				var language = match.Groups["lng"].Value;
-				var culture = new CultureInfo(language);
-				return language;
-			}
-			catch (Exception)
-			{
-				return "en";
-			}
-		}
-
-		string ReadLanguageFilename(string fileName)
-		{
-			try
-			{
-				fileName = Path.GetFileName(fileName);
-				var match = Regex.Match(fileName, @"(?<file>.+)\.(?<lng>.+)\.resx");
-				var file = match.Groups["file"].Value;
-				if (string.IsNullOrWhiteSpace(file))
-				{
-					file = Path.GetFileNameWithoutExtension(fileName);
-				}
-				return file;
-			}
-			catch (Exception)
-			{
-				return "res";
-			}
-		}
-
-
-
-		bool ValidateResxTranslate()
-		{
-			string errors = "";
-
-			if (!File.Exists(txtSourceResx.Text))
-				errors += "Please select source ResX file.\n";
-			if (cmbSourceResxLng.SelectedIndex == -1)
-				errors += "Please select source ResX file's language.\n";
-			if (!Directory.Exists(txtOutputDir.Text))
-				errors += "Please select output directory.\n";
-
-			bool anychecked = false;
-			foreach (ListViewItem item in lstResxLanguages.Items)
-			{
-				if (item.Checked)
-				{
-					anychecked = true;
-					break;
-				}
-			}
-			if (!anychecked)
-			{
-				errors += "At least one output language should be selected.\n";
-			}
-
-			if (errors.Length > 0)
-			{
-				MessageBox.Show(errors, "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return false;
-			}
-			return true;
-		}
-
-
-		void TranslateResxFiles()
-		{
-			var srcLng = ((KeyValuePair<string, string>)cmbSourceResxLng.SelectedItem).Key;
-			var destLanguages = new List<string>();
-			foreach (ListViewItem item in lstResxLanguages.Items)
-			{
-				if (!item.Checked)
-					continue;
-				if (item.Name == srcLng)
-					continue;
-				destLanguages.Add(item.Name);
-			}
-			if (destLanguages.Count == 0)
-			{
-				MessageBox.Show("The source and the destination languages can not be the same.", "", MessageBoxButtons.OK,
-					MessageBoxIcon.Error);
-				return;
-			}
-
-			IsBusy(true);
-			new Action<string, string, List<string>, string, ResxProgressCallback>(TranslateResxFilesAsync).BeginInvoke(
-				txtSourceResx.Text,
-				srcLng,
-				destLanguages,
-				txtOutputDir.Text,
-				ResxWorkingProgress,
-				(x) => IsBusy(false),
-				null);
-		}
-
-		private delegate void ResxProgressCallback(int max, int pos, string status);
-
-		void TranslateResxFilesAsync(string sourceResx, string sourceLng, List<string> desLanguages, string destDir,
-			ResxProgressCallback progress)
-		{
-			int max = 0;
-			int pos = 0;
-			int trycount = 0;
-			string status = "";
-			bool hasErrors = false;
-
-			var sourceResxFilename = ReadLanguageFilename(sourceResx);
-			var errorLogFilename = sourceResxFilename + ".errors.log";
-			var errorLogFile = Path.Combine(destDir, errorLogFilename);
-
-			foreach (var destLng in desLanguages)
-			{
-				var destFile = Path.Combine(destDir, sourceResxFilename + "." + destLng + ".resx");
-				var doc = new XmlDocument();
-				doc.Load(sourceResx);
-				var dataList = ResxTranslator.ReadResxData(doc);
-				max = dataList.Count;
-
-				pos = 0;
-				status = "Translating language: " + destLng;
-				progress.BeginInvoke(max, pos, status, null, null);
-
-				try
-				{
-
-					foreach (var node in dataList)
-					{
-						status = "Translating language: " + destLng;
-						pos += 1;
-						progress.BeginInvoke(max, pos, status, null, null);
-
-
-						var valueNode = ResxTranslator.GetDataValueNode(node);
-						if (valueNode == null) continue;
-
-						var orgText = valueNode.InnerText;
-						if (string.IsNullOrWhiteSpace(orgText))
-							continue;
-
-						// There is no longer a key to validate
-						// the key
-						var textTranslatorUrlKey = "";
-
-						string translated = string.Empty;
-						bool success = false;
-						trycount = 0;
-						do
-						{
-							try
-							{
-								success = GTranslateService.Translate(orgText, sourceLng, destLng, textTranslatorUrlKey, out translated);
-							}
-							catch (Exception)
-							{
-								success = false;
-							}
-							trycount++;
-
-							if (!success)
-							{
-								var key = ResxTranslator.GetDataKeyName(node);
-								status = "Translating language: " + destLng + " , key '" + key + "' failed to translate in try " + trycount;
-								progress.BeginInvoke(max, pos, status, null, null);
-							}
-
-						} while (success == false && trycount <= 2);
-
-						if (success)
-						{
-							valueNode.InnerText = translated;
-						}
-						else
-						{
-							hasErrors = true;
-							var key = ResxTranslator.GetDataKeyName(node);
-							try
-							{
-								string message = "\r\nKey '" + key + "' translation to language '" + destLng + "' failed.";
-								File.AppendAllText(errorLogFile, message);
-							}
-							catch
-							{
-							}
-						}
-					}
-				}
-				finally
-				{
-					// now save that shit!
-					doc.Save(destFile);
-				}
-			}
-
-			if (hasErrors)
-			{
-				status = "Translation finished. Errors are logged in to '" + errorLogFilename + "'.";
-			}
-			else
-			{
-				status = "Translation finished.";
-			}
-
-
-			progress.BeginInvoke(max, pos, status, null, null);
-
-		}
-
-		void ResxWorkingProgress(int max, int pos, string status)
-		{
-			if (this.InvokeRequired)
-			{
-				this.BeginInvoke(new ResxProgressCallback(ResxWorkingProgress), max, pos, status);
-				return;
-			}
-			else
-			{
-				barResxProgress.Minimum = 0;
-				barResxProgress.Maximum = max;
-				barResxProgress.Value = pos;
-				lblResxTranslateStatus.Text = string.Format("Processing {0:00}/{1:00}, ", max, pos) + status;
-			}
-		}
-
-
-		void ImportExcel()
-		{
-			var sheetName = cmbExcelSheets.Text;
-			var excelFile = txtExcelFile.Text;
-			var resxFile = txtExcelResx.Text;
-			var sheetKeyColumn = cmbExcelKey.Text;
-			var sheetTranslation = cmbExcelTranslation.Text;
-			var create = chkExcelCreateAbsent.Checked;
-
-			IsBusy(true);
-			new Action<string, string, string, string, string, bool>(ImportExcel).BeginInvoke(
-				excelFile,
-				resxFile,
-				sheetName,
-				sheetKeyColumn,
-				sheetTranslation,
-				create,
-				(x) => IsBusy(false),
-				null);
-		}
-
-		private void ImportExcel(string excelFile, string resxFile, string sheetName, string sheetKeyColumn,
-			string sheetTranslation, bool create)
-		{
-			var doc = new XmlDocument();
-			doc.Load(resxFile);
-			var dataList = ResxTranslator.ReadResxData(doc);
-
-			var excelLanguages = ResxExcel.ReadExcelLanguage(excelFile, sheetName, sheetKeyColumn, sheetTranslation);
-			foreach (var lngPair in excelLanguages)
-			{
-				var node = dataList.FirstOrDefault(x => ResxTranslator.GetDataKeyName(x) == lngPair.Key);
-				if (node != null)
-				{
-					ResxTranslator.SetDataValue(doc, node, lngPair.Value);
-				}
-				else
-				{
-					ResxTranslator.AddLanguageNode(doc, lngPair.Key, lngPair.Value);
-				}
-			}
-			doc.PreserveWhitespace = false;
-			var writer = new XmlTextWriter(resxFile, Encoding.UTF8);
-			writer.Formatting = Formatting.Indented;
-			doc.Save(writer);
-			writer.Close();
-		}
-
-		internal delegate OpResult GetGoogleTranslatorKeyDeligate(string textToTranslate);
-
-		#region Old core to read old GoogleTranslation Validation Key
-
-		//internal OpResult GetGoogleTranslatorKey(string textToTranslate)
-		//{
-		//	if (IsGoogleTranslatorLoaded())
-		//	{
-		//		try
-		//		{
-		//			// ReSharper disable once PossibleNullReferenceException
-		//			object result = webBrowser.Document.InvokeScript("Vj", new object[] { textToTranslate });
-		//			if (result == null)
-		//			{
-		//				return new OpResult
-		//				{
-		//					Success = false,
-		//					Result = "Failed to find the translation function! Cantact the author please.\n"
-		//				};
-		//			}
-		//			return new OpResult
-		//			{
-		//				Success = true,
-		//				Result = result.ToString()
-		//			};
-		//		}
-		//		catch (Exception ex)
-		//		{
-		//			return new OpResult
-		//			{
-		//				Success = false,
-		//				Result = ex.Message
-		//			};
-		//		}
-		//	}
-		//	else
-		//	{
-		//		return new OpResult
-		//		{
-		//			Success = false,
-		//			Result = "Google Translator is not loaded yet!"
-		//		};
-		//	}
-		//}
-
-		//internal OpResult GetGoogleTranslatorKey_UiThread(string textToTranslate)
-		//{
-		//	if (this.InvokeRequired)
-		//	{
-		//		var asyncHandler = this.BeginInvoke(new GetGoogleTranslatorKeyDeligate(GetGoogleTranslatorKey),
-		//			new object[] {textToTranslate});
-
-		//		asyncHandler.AsyncWaitHandle.WaitOne();
-
-		//		var result = this.EndInvoke(asyncHandler) as OpResult;
-		//		if (result != null)
-		//		{
-		//			return result;
-		//		}
-		//		return new OpResult()
-		//		{
-		//			Success = false,
-		//			Result = "Failed to get the key for the translator from main ui thread."
-		//		};
-		//	}
-		//	else
-		//	{
-		//		return GetGoogleTranslatorKey(textToTranslate);
-		//	}
-		//}
-
-		#endregion
-
-
-		bool IsGoogleTranslatorLoaded()
-		{
-			if (webBrowser.Document != null &&
-				(webBrowser.ReadyState == WebBrowserReadyState.Loaded ||
-				 webBrowser.ReadyState == WebBrowserReadyState.Complete))
-			{
-				return true;
-			}
-			return false;
-		}
-
-		private void frmMain_Load(object sender, EventArgs e)
-		{
-			FillComboBoxes();
-			tabMain.TabPages.Remove(tabBrowser);
-		}
-
-		private void btnTranslate_Click(object sender, EventArgs e)
-		{
-
-			if (cmbDesc.SelectedIndex == -1 || cmbSrc.SelectedIndex == -1)
-			{
-				MessageBox.Show("Please select source and destination languages correctly.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-			if (txtSrc.Text.Length == 0)
-			{
-				MessageBox.Show("The text body can not be empty.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-
-			var lngSrc = ((KeyValuePair<string, string>)cmbSrc.SelectedItem).Key;
-			var lngDest = ((KeyValuePair<string, string>)cmbDesc.SelectedItem).Key;
-			var text = txtSrc.Text;
-
-			// There is no longer a key to validate
-			var textTranslatorUrlKey = "";
-
-			IsBusy(true);
-			GTranslateService.TranslateAsync(
-				text, lngSrc, lngDest, textTranslatorUrlKey,
-				(success, result) =>
-				{
-					SetResult(result);
-					IsBusy(false);
-				});
-		}
-
-		private void btnSelectResxSource_Click(object sender, EventArgs e)
-		{
-			var dlg = new OpenFileDialog();
-			dlg.Filter = "ResourceX File|*.resx";
-			if (dlg.ShowDialog() == DialogResult.OK)
-			{
-				txtSourceResx.Text = dlg.FileName;
-				if (txtOutputDir.Text.Length == 0)
-				{
-					txtOutputDir.Text = Path.GetDirectoryName(txtSourceResx.Text);
-				}
-
-				var lng = ReadLanguageName(txtSourceResx.Text);
-				var key = _languages.FirstOrDefault(x => string.Compare(x.Key, lng, StringComparison.InvariantCultureIgnoreCase) == 0);
-				if (key.Key != null)
-					cmbSourceResxLng.SelectedItem = key;
-				else
-				{
-					lng = "en";
-					key = _languages.FirstOrDefault(x => string.Compare(x.Key, lng, StringComparison.InvariantCultureIgnoreCase) == 0);
-					if (key.Key != null)
-						cmbSourceResxLng.SelectedItem = key;
-				}
-			}
-		}
-
-		private void btnSelectOutputDir_Click(object sender, EventArgs e)
-		{
-			var dlg = new FolderBrowserDialog();
-			dlg.ShowNewFolderButton = true;
-			dlg.RootFolder = Environment.SpecialFolder.MyComputer;
-			if (txtOutputDir.Text.Length > 0)
-			{
-				dlg.SelectedPath = txtOutputDir.Text;
-			}
-			if (dlg.ShowDialog() == DialogResult.OK)
-			{
-				txtOutputDir.Text = dlg.SelectedPath;
-			}
-		}
-
-
-		private void btnStartResxTranslate_Click(object sender, EventArgs e)
-		{
-			if (!ValidateResxTranslate())
-				return;
-			if (!IsGoogleTranslatorLoaded())
-			{
-				MessageBox.Show("Google Translator is not loaded.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-
-			TranslateResxFiles();
-		}
-
-		private void lnkAbout_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-		{
-			using (var frm = new frmAbout())
-			{
-				frm.ShowDialog();
-			}
-		}
-
-		private void btnOpenExcel_Click(object sender, EventArgs e)
-		{
-			if (!File.Exists(txtExcelFile.Text))
-			{
-				MessageBox.Show("Please select an excel file.", "Excel", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-
-			var excel = ResxExcel.ReadExcel(txtExcelFile.Text);
-			if (excel == null)
-			{
-				MessageBox.Show("Failed to read excel file", "Excel", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-			cmbExcelSheets.DataSource = excel.SheetNames;
-			cmbExcelKey.DataSource = excel.SheetColumns;
-			cmbExcelTranslation.DataSource = excel.SheetColumns;
-			if (Array.IndexOf(excel.SheetColumns, "Name") != -1)
-			{
-				cmbExcelKey.SelectedValue = "Name";
-			}
-			btnImportExcel.Enabled = true;
-		}
-
-		private void btnSelectExcel_Click(object sender, EventArgs e)
-		{
-			var dlg = new OpenFileDialog();
-			dlg.Filter = "Excel File|*.xls;xlsx";
-			if (dlg.ShowDialog() == DialogResult.OK)
-			{
-				txtExcelFile.Text = dlg.FileName;
-			}
-		}
-
-		private void btnExcelResx_Click(object sender, EventArgs e)
-		{
-			var dlg = new OpenFileDialog();
-			dlg.Filter = "ResourceX File|*.resx";
-			if (dlg.ShowDialog() == DialogResult.OK)
-			{
-				txtExcelResx.Text = dlg.FileName;
-			}
-		}
-
-		private void cmbExcelSheets_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			if (string.IsNullOrWhiteSpace(txtExcelFile.Text))
-				return;
-			if (!File.Exists(txtExcelFile.Text))
-			{
-				MessageBox.Show("Please select an excel file.", "Select Resx", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-
-			if (cmbExcelSheets.SelectedIndex != -1)
-			{
-				var cols = ResxExcel.GetExcelSheetColumns(txtExcelFile.Text, cmbExcelSheets.Text);
-				cmbExcelKey.DataSource = cols;
-				var cols2 = ResxExcel.GetExcelSheetColumns(txtExcelFile.Text, cmbExcelSheets.Text);
-				cmbExcelTranslation.DataSource = cols2;
-				if (Array.IndexOf(cols, "Name") != -1)
-				{
-					cmbExcelKey.Text = "Name";
-				}
-			}
-		}
-
-		private void btnImportExcel_Click(object sender, EventArgs e)
-		{
-			if (!File.Exists(txtExcelResx.Text))
-			{
-				MessageBox.Show("Please select ResX file.", "Select Resx", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-			if (!File.Exists(txtExcelFile.Text))
-			{
-				MessageBox.Show("Please select an excel file.", "Select Resx", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-			if (cmbExcelSheets.Items.Count == 0)
-			{
-				MessageBox.Show("Please open excel file and select key and translation columns.", "Open Excel", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-			if (cmbExcelKey.SelectedIndex == -1 || cmbExcelSheets.SelectedIndex == -1 || cmbExcelTranslation.SelectedIndex == -1)
-			{
-				MessageBox.Show("Please select excel columns.", "Select Columns", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				return;
-			}
-
-			ImportExcel();
-		}
-
-		private void webBrowser_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)
-		{
-			HtmlDocument doc = webBrowser.Document;
-			if (doc != null)
-				foreach (HtmlElement imgElemt in doc.Images)
-				{
-					imgElemt.SetAttribute("src", "");
-				}
-		}
-	}
+    public partial class frmMain : Form
+    {
+        public static ServiceEnum PreferedService = ServiceEnum.Google;
+        public frmMain()
+        {
+            InitializeComponent();
+        }
+
+        private readonly Dictionary<string, string> _languages =
+            new Dictionary<string, string>
+            {
+                {"auto", "(Detect)"},
+                {"af", "Afrikaans"},
+                {"sq", "Albanian"},
+                {"ar", "Arabic"},
+                {"hy", "Armenian"},
+                {"az", "Azerbaijani"},
+                {"eu", "Basque"},
+                {"be", "Belarusian"},
+                {"bn", "Bengali"},
+                {"bg", "Bulgarian"},
+                {"ca", "Catalan"},
+                {"zh-CN", "Chinese (Simplified)"},
+                {"zh-TW", "Chinese (Traditional)"},
+                {"hr", "Croatian"},
+                {"cs", "Czech"},
+                {"da", "Danish"},
+                {"nl", "Dutch"},
+                {"en", "English"},
+                {"eo", "Esperanto"},
+                {"et", "Estonian"},
+                {"tl", "Filipino"},
+                {"fi", "Finnish"},
+                {"fr", "French"},
+                {"gl", "Galician"},
+                {"ka", "Georgian"},
+                {"de", "German"},
+                {"el", "Greek"},
+                {"gu", "Gujarati"},
+                {"ht", "Haitian Creole"},
+                {"iw", "Hebrew"},
+                {"hi", "Hindi"},
+                {"hu", "Hungarian"},
+                {"is", "Icelandic"},
+                {"id", "Indonesian"},
+                {"ga", "Irish"},
+                {"it", "Italian"},
+                {"ja", "Japanese"},
+                {"kn", "Kannada"},
+                {"km", "Khmer"},
+                {"ko", "Korean"},
+                {"lo", "Lao"},
+                {"la", "Latin"},
+                {"lv", "Latvian"},
+                {"lt", "Lithuanian"},
+                {"mk", "Macedonian"},
+                {"ms", "Malay"},
+                {"mt", "Maltese"},
+                {"no", "Norwegian"},
+                {"fa", "Persian"},
+                {"pl", "Polish"},
+                {"pt", "Portuguese"},
+                {"ro", "Romanian"},
+                {"ru", "Russian"},
+                {"sr", "Serbian"},
+                {"sk", "Slovak"},
+                {"sl", "Slovenian"},
+                {"es", "Spanish"},
+                {"sw", "Swahili"},
+                {"sv", "Swedish"},
+                {"ta", "Tamil"},
+                {"te", "Telugu"},
+                {"th", "Thai"},
+                {"tr", "Turkish"},
+                {"uk", "Ukrainian"},
+                {"ur", "Urdu"},
+                {"vi", "Vietnamese"},
+                {"cy", "Welsh"},
+                {"yi", "Yiddish"}
+            };
+
+
+        void FillComboBoxes()
+        {
+            cmbSrc.DisplayMember = "Value";
+            cmbSrc.ValueMember = "Key";
+
+            cmbDesc.DisplayMember = "Value";
+            cmbDesc.ValueMember = "Key";
+            lstResxLanguages.Items.Clear();
+
+            foreach (var k in _languages)
+            {
+                cmbSrc.Items.Add(k);
+                if (k.Key == "auto")
+                    continue;
+                cmbDesc.Items.Add(k);
+                cmbSourceResxLng.Items.Add(k);
+                lstResxLanguages.Items.Add(k.Key, k.Value, -1);
+            }
+            cmbSrc.SelectedIndex = 0;
+            cmbDesc.Text = "English";
+        }
+
+        void SetResult(string result)
+        {
+            if (this.InvokeRequired)
+            {
+                this.BeginInvoke(new Action<string>(SetResult), result);
+                return;
+            }
+            else
+            {
+                txtDesc.Text = result;
+            }
+        }
+
+        void IsBusy(bool isbusy)
+        {
+            if (this.InvokeRequired)
+            {
+                this.BeginInvoke(new Action<bool>(IsBusy), isbusy);
+                return;
+            }
+            else
+            {
+                tabMain.Enabled = !isbusy;
+            }
+        }
+
+
+        string ReadLanguageName(string fileName)
+        {
+            try
+            {
+                fileName = Path.GetFileName(fileName);
+                var match = Regex.Match(fileName, @".+\.(?<lng>.+)\.resx");
+                var language = match.Groups["lng"].Value;
+                var culture = new CultureInfo(language);
+                return language;
+            }
+            catch (Exception)
+            {
+                return "en";
+            }
+        }
+
+        string ReadLanguageFilename(string fileName)
+        {
+            try
+            {
+                fileName = Path.GetFileName(fileName);
+                var match = Regex.Match(fileName, @"(?<file>.+)\.(?<lng>.+)\.resx");
+                var file = match.Groups["file"].Value;
+                if (string.IsNullOrWhiteSpace(file))
+                {
+                    file = Path.GetFileNameWithoutExtension(fileName);
+                }
+                return file;
+            }
+            catch (Exception)
+            {
+                return "res";
+            }
+        }
+
+
+
+        bool ValidateResxTranslate()
+        {
+            string errors = "";
+
+            if (!File.Exists(txtSourceResx.Text))
+                errors += "Please select source ResX file.\n";
+            if (cmbSourceResxLng.SelectedIndex == -1)
+                errors += "Please select source ResX file's language.\n";
+            if (!Directory.Exists(txtOutputDir.Text))
+                errors += "Please select output directory.\n";
+
+            bool anychecked = false;
+            foreach (ListViewItem item in lstResxLanguages.Items)
+            {
+                if (item.Checked)
+                {
+                    anychecked = true;
+                    break;
+                }
+            }
+            if (!anychecked)
+            {
+                errors += "At least one output language should be selected.\n";
+            }
+
+            if (errors.Length > 0)
+            {
+                MessageBox.Show(errors, "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+            return true;
+        }
+
+
+        void TranslateResxFiles()
+        {
+            var srcLng = ((KeyValuePair<string, string>)cmbSourceResxLng.SelectedItem).Key;
+            var destLanguages = new List<string>();
+            foreach (ListViewItem item in lstResxLanguages.Items)
+            {
+                if (!item.Checked)
+                    continue;
+                if (item.Name == srcLng)
+                    continue;
+                destLanguages.Add(item.Name);
+            }
+            if (destLanguages.Count == 0)
+            {
+                MessageBox.Show("The source and the destination languages can not be the same.", "", MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return;
+            }
+
+            IsBusy(true);
+            new Action<string, string, List<string>, string, ResxProgressCallback>(TranslateResxFilesAsync).BeginInvoke(
+                txtSourceResx.Text,
+                srcLng,
+                destLanguages,
+                txtOutputDir.Text,
+                ResxWorkingProgress,
+                (x) => IsBusy(false),
+                null);
+        }
+
+        private delegate void ResxProgressCallback(int max, int pos, string status);
+
+        async void TranslateResxFilesAsync(string sourceResx, string sourceLng, List<string> desLanguages, string destDir,
+            ResxProgressCallback progress)
+        {
+            int max = 0;
+            int pos = 0;
+            int trycount = 0;
+            string status = "";
+            bool hasErrors = false;
+
+            var sourceResxFilename = ReadLanguageFilename(sourceResx);
+            var errorLogFilename = sourceResxFilename + ".errors.log";
+            var errorLogFile = Path.Combine(destDir, errorLogFilename);
+
+            foreach (var destLng in desLanguages)
+            {
+                var destFile = Path.Combine(destDir, sourceResxFilename + "." + destLng + ".resx");
+                var doc = new XmlDocument();
+                doc.Load(sourceResx);
+                var dataList = ResxTranslator.ReadResxData(doc);
+                max = dataList.Count;
+
+                pos = 0;
+                status = "Translating language: " + destLng;
+                progress.BeginInvoke(max, pos, status, null, null);
+
+                try
+                {
+
+                    foreach (var node in dataList)
+                    {
+                        status = "Translating language: " + destLng;
+                        pos += 1;
+                        progress.BeginInvoke(max, pos, status, null, null);
+
+
+                        var valueNode = ResxTranslator.GetDataValueNode(node);
+                        if (valueNode == null) continue;
+
+                        var orgText = valueNode.InnerText;
+                        if (string.IsNullOrWhiteSpace(orgText))
+                            continue;
+
+                        if (frmMain.PreferedService == ServiceEnum.Google)
+                        {
+                            // There is no longer a key to validate
+                            // the key
+                            var textTranslatorUrlKey = "";
+
+                            string translated = string.Empty;
+                            bool success = false;
+                            trycount = 0;
+                            do
+                            {
+                                try
+                                {
+
+                                    success = GTranslateService.Translate(orgText, sourceLng, destLng, textTranslatorUrlKey, out translated);
+                                }
+                                catch (Exception)
+                                {
+                                    success = false;
+                                }
+                                trycount++;
+
+                                if (!success)
+                                {
+                                    var key = ResxTranslator.GetDataKeyName(node);
+                                    status = "Translating language: " + destLng + " , key '" + key + "' failed to translate in try " + trycount;
+                                    progress.BeginInvoke(max, pos, status, null, null);
+                                }
+
+                            } while (success == false && trycount <= 2);
+
+                            if (success)
+                            {
+                                valueNode.InnerText = translated;
+                            }
+                            else
+                            {
+                                hasErrors = true;
+                                var key = ResxTranslator.GetDataKeyName(node);
+                                try
+                                {
+                                    string message = "\r\nKey '" + key + "' translation to language '" + destLng + "' failed.";
+                                    File.AppendAllText(errorLogFile, message);
+                                }
+                                catch
+                                {
+                                }
+                            }
+                        }
+                        else if (frmMain.PreferedService == ServiceEnum.Microsoft)
+                        {
+                            valueNode.InnerText = await MSTranslateService.TranslateAsync(orgText, sourceLng, destLng);
+                        }
+                    }
+                }
+                finally
+                {
+                    // now save that shit!
+                    doc.Save(destFile);
+                }
+            }
+
+            if (hasErrors)
+            {
+                status = "Translation finished. Errors are logged in to '" + errorLogFilename + "'.";
+            }
+            else
+            {
+                status = "Translation finished.";
+            }
+
+
+            progress.BeginInvoke(max, pos, status, null, null);
+
+        }
+
+        void ResxWorkingProgress(int max, int pos, string status)
+        {
+            if (this.InvokeRequired)
+            {
+                this.BeginInvoke(new ResxProgressCallback(ResxWorkingProgress), max, pos, status);
+                return;
+            }
+            else
+            {
+                barResxProgress.Minimum = 0;
+                barResxProgress.Maximum = max;
+                barResxProgress.Value = pos;
+                lblResxTranslateStatus.Text = string.Format("Processing {0:00}/{1:00}, ", max, pos) + status;
+            }
+        }
+
+
+        void ImportExcel()
+        {
+            var sheetName = cmbExcelSheets.Text;
+            var excelFile = txtExcelFile.Text;
+            var resxFile = txtExcelResx.Text;
+            var sheetKeyColumn = cmbExcelKey.Text;
+            var sheetTranslation = cmbExcelTranslation.Text;
+            var create = chkExcelCreateAbsent.Checked;
+
+            IsBusy(true);
+            new Action<string, string, string, string, string, bool>(ImportExcel).BeginInvoke(
+                excelFile,
+                resxFile,
+                sheetName,
+                sheetKeyColumn,
+                sheetTranslation,
+                create,
+                (x) => IsBusy(false),
+                null);
+        }
+
+        private void ImportExcel(string excelFile, string resxFile, string sheetName, string sheetKeyColumn,
+            string sheetTranslation, bool create)
+        {
+            var doc = new XmlDocument();
+            doc.Load(resxFile);
+            var dataList = ResxTranslator.ReadResxData(doc);
+
+            var excelLanguages = ResxExcel.ReadExcelLanguage(excelFile, sheetName, sheetKeyColumn, sheetTranslation);
+            foreach (var lngPair in excelLanguages)
+            {
+                var node = dataList.FirstOrDefault(x => ResxTranslator.GetDataKeyName(x) == lngPair.Key);
+                if (node != null)
+                {
+                    ResxTranslator.SetDataValue(doc, node, lngPair.Value);
+                }
+                else
+                {
+                    ResxTranslator.AddLanguageNode(doc, lngPair.Key, lngPair.Value);
+                }
+            }
+            doc.PreserveWhitespace = false;
+            var writer = new XmlTextWriter(resxFile, Encoding.UTF8);
+            writer.Formatting = Formatting.Indented;
+            doc.Save(writer);
+            writer.Close();
+        }
+
+        internal delegate OpResult GetGoogleTranslatorKeyDeligate(string textToTranslate);
+
+        #region Old core to read old GoogleTranslation Validation Key
+
+        //internal OpResult GetGoogleTranslatorKey(string textToTranslate)
+        //{
+        //	if (IsGoogleTranslatorLoaded())
+        //	{
+        //		try
+        //		{
+        //			// ReSharper disable once PossibleNullReferenceException
+        //			object result = webBrowser.Document.InvokeScript("Vj", new object[] { textToTranslate });
+        //			if (result == null)
+        //			{
+        //				return new OpResult
+        //				{
+        //					Success = false,
+        //					Result = "Failed to find the translation function! Cantact the author please.\n"
+        //				};
+        //			}
+        //			return new OpResult
+        //			{
+        //				Success = true,
+        //				Result = result.ToString()
+        //			};
+        //		}
+        //		catch (Exception ex)
+        //		{
+        //			return new OpResult
+        //			{
+        //				Success = false,
+        //				Result = ex.Message
+        //			};
+        //		}
+        //	}
+        //	else
+        //	{
+        //		return new OpResult
+        //		{
+        //			Success = false,
+        //			Result = "Google Translator is not loaded yet!"
+        //		};
+        //	}
+        //}
+
+        //internal OpResult GetGoogleTranslatorKey_UiThread(string textToTranslate)
+        //{
+        //	if (this.InvokeRequired)
+        //	{
+        //		var asyncHandler = this.BeginInvoke(new GetGoogleTranslatorKeyDeligate(GetGoogleTranslatorKey),
+        //			new object[] {textToTranslate});
+
+        //		asyncHandler.AsyncWaitHandle.WaitOne();
+
+        //		var result = this.EndInvoke(asyncHandler) as OpResult;
+        //		if (result != null)
+        //		{
+        //			return result;
+        //		}
+        //		return new OpResult()
+        //		{
+        //			Success = false,
+        //			Result = "Failed to get the key for the translator from main ui thread."
+        //		};
+        //	}
+        //	else
+        //	{
+        //		return GetGoogleTranslatorKey(textToTranslate);
+        //	}
+        //}
+
+        #endregion
+
+
+        bool IsGoogleTranslatorLoaded()
+        {
+            if (webBrowser.Document != null &&
+                (webBrowser.ReadyState == WebBrowserReadyState.Loaded ||
+                 webBrowser.ReadyState == WebBrowserReadyState.Complete))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private void frmMain_Load(object sender, EventArgs e)
+        {
+            FillComboBoxes();
+            tabMain.TabPages.Remove(tabBrowser);
+        }
+
+        private async void btnTranslate_ClickAsync(object sender, EventArgs e)
+        {
+
+            if (cmbDesc.SelectedIndex == -1 || cmbSrc.SelectedIndex == -1)
+            {
+                MessageBox.Show("Please select source and destination languages correctly.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+            if (txtSrc.Text.Length == 0)
+            {
+                MessageBox.Show("The text body can not be empty.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var lngSrc = ((KeyValuePair<string, string>)cmbSrc.SelectedItem).Key;
+            var lngDest = ((KeyValuePair<string, string>)cmbDesc.SelectedItem).Key;
+            var text = txtSrc.Text;
+                        
+            IsBusy(true);
+
+            if (frmMain.PreferedService == ServiceEnum.Google)
+            {
+                // There is no longer a key to validate
+                var textTranslatorUrlKey = "";
+
+                GTranslateService.TranslateAsync(
+                text, lngSrc, lngDest, textTranslatorUrlKey,
+                (success, result) =>
+                {
+                    SetResult(result);
+                    IsBusy(false);
+                });
+            }
+            else if (frmMain.PreferedService == ServiceEnum.Microsoft)
+            {
+                string result = await MSTranslateService.TranslateAsync(text, lngSrc, lngDest);
+
+                SetResult(result == null ? string.Empty : result);
+                IsBusy(false);
+            }
+        }
+
+        private void btnSelectResxSource_Click(object sender, EventArgs e)
+        {
+            var dlg = new OpenFileDialog();
+            dlg.Filter = "ResourceX File|*.resx";
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                txtSourceResx.Text = dlg.FileName;
+                if (txtOutputDir.Text.Length == 0)
+                {
+                    txtOutputDir.Text = Path.GetDirectoryName(txtSourceResx.Text);
+                }
+
+                var lng = ReadLanguageName(txtSourceResx.Text);
+                var key = _languages.FirstOrDefault(x => string.Compare(x.Key, lng, StringComparison.InvariantCultureIgnoreCase) == 0);
+                if (key.Key != null)
+                    cmbSourceResxLng.SelectedItem = key;
+                else
+                {
+                    lng = "en";
+                    key = _languages.FirstOrDefault(x => string.Compare(x.Key, lng, StringComparison.InvariantCultureIgnoreCase) == 0);
+                    if (key.Key != null)
+                        cmbSourceResxLng.SelectedItem = key;
+                }
+            }
+        }
+
+        private void btnSelectOutputDir_Click(object sender, EventArgs e)
+        {
+            var dlg = new FolderBrowserDialog();
+            dlg.ShowNewFolderButton = true;
+            dlg.RootFolder = Environment.SpecialFolder.MyComputer;
+            if (txtOutputDir.Text.Length > 0)
+            {
+                dlg.SelectedPath = txtOutputDir.Text;
+            }
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                txtOutputDir.Text = dlg.SelectedPath;
+            }
+        }
+
+
+        private void btnStartResxTranslate_Click(object sender, EventArgs e)
+        {
+            if (!ValidateResxTranslate())
+                return;
+            if (!IsGoogleTranslatorLoaded())
+            {
+                MessageBox.Show("Google Translator is not loaded.", "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            TranslateResxFiles();
+        }
+
+        private void lnkAbout_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            using (var frm = new frmAbout())
+            {
+                frm.ShowDialog();
+            }
+        }
+
+        private void btnOpenExcel_Click(object sender, EventArgs e)
+        {
+            if (!File.Exists(txtExcelFile.Text))
+            {
+                MessageBox.Show("Please select an excel file.", "Excel", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var excel = ResxExcel.ReadExcel(txtExcelFile.Text);
+            if (excel == null)
+            {
+                MessageBox.Show("Failed to read excel file", "Excel", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+            cmbExcelSheets.DataSource = excel.SheetNames;
+            cmbExcelKey.DataSource = excel.SheetColumns;
+            cmbExcelTranslation.DataSource = excel.SheetColumns;
+            if (Array.IndexOf(excel.SheetColumns, "Name") != -1)
+            {
+                cmbExcelKey.SelectedValue = "Name";
+            }
+            btnImportExcel.Enabled = true;
+        }
+
+        private void btnSelectExcel_Click(object sender, EventArgs e)
+        {
+            var dlg = new OpenFileDialog();
+            dlg.Filter = "Excel File|*.xls;xlsx";
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                txtExcelFile.Text = dlg.FileName;
+            }
+        }
+
+        private void btnExcelResx_Click(object sender, EventArgs e)
+        {
+            var dlg = new OpenFileDialog();
+            dlg.Filter = "ResourceX File|*.resx";
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                txtExcelResx.Text = dlg.FileName;
+            }
+        }
+
+        private void cmbExcelSheets_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtExcelFile.Text))
+                return;
+            if (!File.Exists(txtExcelFile.Text))
+            {
+                MessageBox.Show("Please select an excel file.", "Select Resx", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (cmbExcelSheets.SelectedIndex != -1)
+            {
+                var cols = ResxExcel.GetExcelSheetColumns(txtExcelFile.Text, cmbExcelSheets.Text);
+                cmbExcelKey.DataSource = cols;
+                var cols2 = ResxExcel.GetExcelSheetColumns(txtExcelFile.Text, cmbExcelSheets.Text);
+                cmbExcelTranslation.DataSource = cols2;
+                if (Array.IndexOf(cols, "Name") != -1)
+                {
+                    cmbExcelKey.Text = "Name";
+                }
+            }
+        }
+
+        private void btnImportExcel_Click(object sender, EventArgs e)
+        {
+            if (!File.Exists(txtExcelResx.Text))
+            {
+                MessageBox.Show("Please select ResX file.", "Select Resx", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+            if (!File.Exists(txtExcelFile.Text))
+            {
+                MessageBox.Show("Please select an excel file.", "Select Resx", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+            if (cmbExcelSheets.Items.Count == 0)
+            {
+                MessageBox.Show("Please open excel file and select key and translation columns.", "Open Excel", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+            if (cmbExcelKey.SelectedIndex == -1 || cmbExcelSheets.SelectedIndex == -1 || cmbExcelTranslation.SelectedIndex == -1)
+            {
+                MessageBox.Show("Please select excel columns.", "Select Columns", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            ImportExcel();
+        }
+
+        private void webBrowser_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)
+        {
+            HtmlDocument doc = webBrowser.Document;
+            if (doc != null)
+                foreach (HtmlElement imgElemt in doc.Images)
+                {
+                    imgElemt.SetAttribute("src", "");
+                }
+        }
+
+        private void radioButtonGoogleTranslateService_CheckedChanged(object sender, EventArgs e)
+        {
+            if (sender is RadioButton rb && rb.Checked)
+            {
+                frmMain.PreferedService = ServiceEnum.Google;
+            }
+
+        }
+
+        private void radioButtonMSTranslateService_CheckedChanged(object sender, EventArgs e)
+        {
+            if (sender is RadioButton rb && rb.Checked)
+            {
+                frmMain.PreferedService = ServiceEnum.Microsoft;
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Addition of Microsoft Cognitive Translations service
We have leveraged Microsoft's Cognitive Translations service for providing the translations. We already have free translations service provided by Google. However, the free service by Google has limited throughput. This is noticeable especially when translation resources file.
Addition of Microsoft's Cognitive Translations service would enable people who have a subscription to the Azure Cognitive services to leverage it and get fast performance.

### Addition of new tab for selecting the preferred Translations service
We have added a new tab for a selection of Preferred Translation service. By default, Google translation service is used. User can select the Microsoft radio button to change the preferred translation service to Microsoft Cognitive Translations service.
frmMain has the PreferredService variable, depending on which respective service is invokes for translation.